### PR TITLE
Add Mifos support for periodic loan charges

### DIFF
--- a/src/app/core/utils/charge-time-type.spec.ts
+++ b/src/app/core/utils/charge-time-type.spec.ts
@@ -1,0 +1,49 @@
+import {
+  formatPeriodicLoanChargeSummary,
+  isPeriodicLoanChargeTime,
+  isSpecifiedDueDateChargeTime
+} from './charge-time-type';
+
+describe('charge-time-type utils', () => {
+  it('detects periodic loan charges by code', () => {
+    expect(
+      isPeriodicLoanChargeTime({
+        code: 'chargeTimeType.loanPeriodic',
+        id: 999,
+        value: 'Something else'
+      })
+    ).toBe(true);
+  });
+
+  it('detects periodic loan charges by id', () => {
+    expect(isPeriodicLoanChargeTime(17)).toBe(true);
+  });
+
+  it('detects specified due date charges by code', () => {
+    expect(isSpecifiedDueDateChargeTime({ code: 'chargeTimeType.specifiedDueDate' })).toBe(true);
+  });
+
+  it('formats yearly periodic recurrence summaries', () => {
+    expect(
+      formatPeriodicLoanChargeSummary({
+        feeInterval: 1,
+        feeFrequency: { code: 'YEARS', value: 'Years' }
+      })
+    ).toBe('Every 1 year, starts on first repayment date');
+  });
+
+  it('pluralizes periodic recurrence summaries when interval is greater than one', () => {
+    expect(
+      formatPeriodicLoanChargeSummary({
+        feeInterval: 2,
+        feeFrequency: { code: 'MONTHS', value: 'Months' }
+      })
+    ).toBe('Every 2 months, starts on first repayment date');
+  });
+
+  it('falls back safely when periodic recurrence fields are incomplete', () => {
+    expect(formatPeriodicLoanChargeSummary({ feeInterval: null, feeFrequency: null })).toBe(
+      'Starts on first repayment date'
+    );
+  });
+});

--- a/src/app/core/utils/charge-time-type.ts
+++ b/src/app/core/utils/charge-time-type.ts
@@ -1,0 +1,209 @@
+import { OptionData } from 'app/shared/models/option-data.model';
+
+export interface ChargeTimeTypeLike {
+  id?: number | null;
+  code?: string | null;
+  value?: string | null;
+}
+
+export interface FeeFrequencyLike {
+  id?: number | null;
+  code?: string | null;
+  value?: string | null;
+}
+
+type ChargeTimeTypeInput = ChargeTimeTypeLike | number | string | null | undefined;
+
+export const ChargeTimeTypeId = {
+  SpecifiedDueDate: 2,
+  AnnualFee: 6,
+  MonthlyFee: 7,
+  OverdueInstallment: 9,
+  WeeklyFee: 11,
+  TrancheDisbursement: 12,
+  LoanPeriodic: 17
+} as const;
+
+export const ChargeTimeTypeCode = {
+  Disbursement: 'chargeTimeType.disbursement',
+  SpecifiedDueDate: 'chargeTimeType.specifiedDueDate',
+  AnnualFee: 'chargeTimeType.annualFee',
+  MonthlyFee: 'chargeTimeType.monthlyFee',
+  OverdueInstallment: 'chargeTimeType.overdueInstallment',
+  WeeklyFee: 'chargeTimeType.weeklyFee',
+  TrancheDisbursement: 'chargeTimeType.trancheDisbursement',
+  LoanPeriodic: 'chargeTimeType.loanPeriodic'
+} as const;
+
+const ChargeTimeTypeValue = {
+  Disbursement: 'Disbursement',
+  SpecifiedDueDate: 'Specified due date',
+  AnnualFee: 'Annual Fee',
+  MonthlyFee: 'Monthly Fee',
+  OverdueInstallment: 'Overdue Installment',
+  WeeklyFee: 'Weekly Fee',
+  TrancheDisbursement: 'Tranche Disbursement',
+  LoanPeriodic: 'Periodic Loan Charge'
+} as const;
+
+function normalizeChargeTimeType(input: ChargeTimeTypeInput): ChargeTimeTypeLike {
+  if (input == null) {
+    return {};
+  }
+
+  if (typeof input === 'number') {
+    return { id: input };
+  }
+
+  if (typeof input === 'string') {
+    return input.startsWith('chargeTimeType.') ? { code: input } : { value: input };
+  }
+
+  return input;
+}
+
+function matchesChargeTimeType(
+  input: ChargeTimeTypeInput,
+  matcher: { id: number; code: string; value: string }
+): boolean {
+  const chargeTimeType = normalizeChargeTimeType(input);
+
+  return (
+    chargeTimeType.code === matcher.code || chargeTimeType.id === matcher.id || chargeTimeType.value === matcher.value
+  );
+}
+
+export function isDisbursementChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: 1,
+    code: ChargeTimeTypeCode.Disbursement,
+    value: ChargeTimeTypeValue.Disbursement
+  });
+}
+
+export function isSpecifiedDueDateChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.SpecifiedDueDate,
+    code: ChargeTimeTypeCode.SpecifiedDueDate,
+    value: ChargeTimeTypeValue.SpecifiedDueDate
+  });
+}
+
+export function isAnnualFeeChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.AnnualFee,
+    code: ChargeTimeTypeCode.AnnualFee,
+    value: ChargeTimeTypeValue.AnnualFee
+  });
+}
+
+export function isMonthlyFeeChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.MonthlyFee,
+    code: ChargeTimeTypeCode.MonthlyFee,
+    value: ChargeTimeTypeValue.MonthlyFee
+  });
+}
+
+export function isOverdueInstallmentChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.OverdueInstallment,
+    code: ChargeTimeTypeCode.OverdueInstallment,
+    value: ChargeTimeTypeValue.OverdueInstallment
+  });
+}
+
+export function isWeeklyFeeChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.WeeklyFee,
+    code: ChargeTimeTypeCode.WeeklyFee,
+    value: ChargeTimeTypeValue.WeeklyFee
+  });
+}
+
+export function isTrancheDisbursementChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.TrancheDisbursement,
+    code: ChargeTimeTypeCode.TrancheDisbursement,
+    value: ChargeTimeTypeValue.TrancheDisbursement
+  });
+}
+
+export function isPeriodicLoanChargeTime(input: ChargeTimeTypeInput): boolean {
+  return matchesChargeTimeType(input, {
+    id: ChargeTimeTypeId.LoanPeriodic,
+    code: ChargeTimeTypeCode.LoanPeriodic,
+    value: ChargeTimeTypeValue.LoanPeriodic
+  });
+}
+
+const periodicFeeFrequencyCodes = new Set([
+  'WEEKS',
+  'MONTHS',
+  'YEARS'
+]);
+const periodicFeeFrequencyValues = new Set([
+  'Weeks',
+  'Months',
+  'Years'
+]);
+
+export function isPeriodicFeeFrequencyOption(option: FeeFrequencyLike | null | undefined): boolean {
+  if (!option) {
+    return false;
+  }
+
+  return periodicFeeFrequencyCodes.has(option.code ?? '') || periodicFeeFrequencyValues.has(option.value ?? '');
+}
+
+export function filterPeriodicFeeFrequencyOptions<T extends FeeFrequencyLike>(options: T[] = []): T[] {
+  return options.filter((option) => isPeriodicFeeFrequencyOption(option));
+}
+
+function getPeriodicFeeUnit(option: FeeFrequencyLike | null | undefined): string | null {
+  if (!option) {
+    return null;
+  }
+
+  const value = option.value?.toLowerCase();
+  if (value && periodicFeeFrequencyValues.has(option.value ?? '')) {
+    return value;
+  }
+
+  switch (option.code) {
+    case 'WEEKS':
+      return 'weeks';
+    case 'MONTHS':
+      return 'months';
+    case 'YEARS':
+      return 'years';
+    default:
+      return null;
+  }
+}
+
+function singularize(unit: string): string {
+  return unit.endsWith('s') ? unit.slice(0, -1) : unit;
+}
+
+export function formatPeriodicLoanChargeSummary(charge: {
+  feeInterval?: number | string | null;
+  feeFrequency?: FeeFrequencyLike | null;
+}): string {
+  const interval = Number(charge.feeInterval);
+  const unit = getPeriodicFeeUnit(charge.feeFrequency);
+
+  if (!Number.isFinite(interval) || interval < 1 || !unit) {
+    return 'Starts on first repayment date';
+  }
+
+  const displayUnit = interval === 1 ? singularize(unit) : unit;
+  return `Every ${interval} ${displayUnit}, starts on first repayment date`;
+}
+
+export function resolveChargeTimeTypeOption(
+  options: OptionData[] | null | undefined,
+  selectedChargeTimeType: number | null | undefined
+): OptionData | undefined {
+  return options?.find((option) => option.id === selectedChargeTimeType);
+}

--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -130,7 +130,7 @@ export class EditLoansAccountComponent {
     const dateFormat = this.settingsService.dateFormat;
     const loanType = 'individual';
     const uniqueCharges = new Map<number | string, any>();
-    (this.loansAccount.charges ?? []).forEach((charge: any) => {
+    this.loansService.filterManualLoanCharges(this.loansAccount.charges ?? []).forEach((charge: any) => {
       const chargeId = charge.chargeId;
       if (chargeId == null) {
         return;

--- a/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
+++ b/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
@@ -183,7 +183,8 @@ export class CreateGlimAccountComponent {
     // const monthDayFormat = 'dd MMMM';
     const data = {
       ...this.loansAccount,
-      charges: (this.loansAccount.charges ?? [])
+      charges: this.loansService
+        .filterManualLoanCharges(this.loansAccount.charges ?? [])
         .map((charge: any) => {
           const chargeId = charge.chargeId ?? charge.id;
           if (chargeId == null) {

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
@@ -57,33 +57,27 @@
     <ng-container matColumnDef="date">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
       <td mat-cell *matCellDef="let charge">
-        @if (charge.chargeTimeType.value === 'Specified due date' || charge.chargeTimeType.value === 'Weekly Fee') {
+        @if (showsDueDate(charge)) {
           <span>
             {{ (charge.dueDate | dateFormat) || 'Unassigned' }}
           </span>
         }
-        @if (charge.chargeTimeType.value === 'Monthly Fee' || charge.chargeTimeType.value === 'Annual Fee') {
+        @if (showsFeeOnMonthDay(charge)) {
           <span>
             {{ (charge.feeOnMonthDay | dateFormat) || 'Unassigned' }}
           </span>
         }
-        @if (
-          !(
-            charge.chargeTimeType.value === 'Monthly Fee' ||
-            charge.chargeTimeType.value === 'Annual Fee' ||
-            charge.chargeTimeType.value === 'Specified due date' ||
-            charge.chargeTimeType.value === 'Weekly Fee'
-          )
-        ) {
+        @if (showsPeriodicSummary(charge)) {
+          <span>
+            {{ getPeriodicChargeSummary(charge) }}
+          </span>
+        }
+        @if (!(showsDueDate(charge) || showsFeeOnMonthDay(charge) || showsPeriodicSummary(charge))) {
           <span>
             {{ 'labels.inputs.N/A' | translate }}
           </span>
         }
-        @if (
-          charge.chargeTimeType.value === 'Weekly Fee' ||
-          charge.chargeTimeType.value === 'Annual Fee' ||
-          charge.chargeTimeType.value === 'Specified due date'
-        ) {
+        @if (canEditChargeDate(charge)) {
           <button mat-icon-button color="primary" (click)="editChargeDate(charge)">
             <fa-icon icon="pen"></fa-icon>
           </button>

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts
@@ -1,0 +1,92 @@
+import { DecimalPipe } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { CdkStepper } from '@angular/cdk/stepper';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import * as solidIcons from '@fortawesome/free-solid-svg-icons';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { LoansAccountChargesStepComponent } from './loans-account-charges-step.component';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+
+describe('LoansAccountChargesStepComponent', () => {
+  let component: LoansAccountChargesStepComponent;
+  let fixture: ComponentFixture<LoansAccountChargesStepComponent>;
+
+  const periodicCharge = {
+    id: 17,
+    chargeId: 17,
+    name: 'Insurance Fee',
+    amount: 20,
+    currency: { displaySymbol: '$' },
+    chargeCalculationType: { value: 'Flat' },
+    chargeTimeType: { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' },
+    feeInterval: 1,
+    feeFrequency: { id: 3, code: 'YEARS', value: 'Years' }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        LoansAccountChargesStepComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: jest.fn(() => ({ afterClosed: () => ({ subscribe: jest.fn() }) }))
+          }
+        },
+        {
+          provide: Dates,
+          useValue: {
+            formatDate: jest.fn((value) => value)
+          }
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            dateFormat: 'dd MMMM yyyy',
+            language: { code: 'en' },
+            decimals: 2
+          }
+        },
+        { provide: CdkStepper, useValue: {} },
+        DecimalPipe,
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    const faIconLibrary = TestBed.inject(FaIconLibrary);
+    const iconList = Object.keys(solidIcons)
+      .filter((key) => key !== 'fas' && key !== 'prefix' && key.startsWith('fa'))
+      .map((icon) => (solidIcons as any)[icon]);
+    faIconLibrary.addIcons(...iconList);
+
+    fixture = TestBed.createComponent(LoansAccountChargesStepComponent);
+    component = fixture.componentInstance;
+    component.loansAccountTemplate = { charges: [periodicCharge] };
+    component.loansAccountProductTemplate = {
+      chargeOptions: [periodicCharge],
+      charges: [periodicCharge],
+      overdueCharges: [],
+      loanPurposeOptions: []
+    };
+    component.loansAccountFormValid = true;
+    component.activeClientMembers = [];
+    component.ngOnChanges();
+    fixture.detectChanges();
+  });
+
+  it('renders a recurrence summary for periodic loan charges before materialization', () => {
+    expect(fixture.nativeElement.textContent).toContain('Every 1 year, starts on first repayment date');
+  });
+
+  it('does not allow date editing for periodic loan charges', () => {
+    expect(component.canEditChargeDate(periodicCharge)).toBe(false);
+  });
+});

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -35,6 +35,14 @@ import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { FormatNumberPipe } from '../../../pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  formatPeriodicLoanChargeSummary,
+  isAnnualFeeChargeTime,
+  isMonthlyFeeChargeTime,
+  isPeriodicLoanChargeTime,
+  isSpecifiedDueDateChargeTime,
+  isWeeklyFeeChargeTime
+} from 'app/core/utils/charge-time-type';
 
 /**
  * Recurring Deposit Account Charges Step
@@ -260,17 +268,16 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
         let newCharge: any;
         const dateFormat = this.settingsService.dateFormat;
         const date = this.dateUtils.formatDate(response.data.value.date, dateFormat);
-        switch (charge.chargeTimeType.value) {
-          case 'Specified due date':
-          case 'Weekly Fee':
-            newCharge = { ...charge, dueDate: date };
-            break;
-          case 'Annual Fee':
-            newCharge = { ...charge, feeOnMonthDay: date };
-            break;
+        if (isSpecifiedDueDateChargeTime(charge.chargeTimeType) || isWeeklyFeeChargeTime(charge.chargeTimeType)) {
+          newCharge = { ...charge, dueDate: date };
+        } else if (isAnnualFeeChargeTime(charge.chargeTimeType)) {
+          newCharge = { ...charge, feeOnMonthDay: date };
         }
-        this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
-        this.chargesDataSource = this.chargesDataSource.concat([]);
+
+        if (newCharge) {
+          this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
+          this.chargesDataSource = this.chargesDataSource.concat([]);
+        }
       }
     });
     this.pristine = false;
@@ -371,5 +378,33 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     const len = this.activeClientMembers.length;
     this.selectAllItems =
       len === 0 ? false : this.activeClientMembers.filter((item: any) => item.selected).length === len;
+  }
+
+  showsDueDate(charge: any): boolean {
+    return (
+      isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
+      isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
+      (isPeriodicLoanChargeTime(charge?.chargeTimeType) && !!charge?.dueDate)
+    );
+  }
+
+  showsFeeOnMonthDay(charge: any): boolean {
+    return isMonthlyFeeChargeTime(charge?.chargeTimeType) || isAnnualFeeChargeTime(charge?.chargeTimeType);
+  }
+
+  showsPeriodicSummary(charge: any): boolean {
+    return isPeriodicLoanChargeTime(charge?.chargeTimeType) && !charge?.dueDate;
+  }
+
+  canEditChargeDate(charge: any): boolean {
+    return (
+      isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
+      isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
+      isAnnualFeeChargeTime(charge?.chargeTimeType)
+    );
+  }
+
+  getPeriodicChargeSummary(charge: any): string {
+    return formatPeriodicLoanChargeSummary(charge);
   }
 }

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -320,24 +320,22 @@
         <ng-container matColumnDef="date">
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
           <td mat-cell *matCellDef="let charge">
-            @if (charge.chargeTimeType.value === 'Specified due date' || charge.chargeTimeType.value === 'Weekly Fee') {
+            @if (showsDueDate(charge)) {
               <span>
                 {{ (charge.dueDate | dateFormat) || 'Unassigned' }}
               </span>
             }
-            @if (charge.chargeTimeType.value === 'Monthly Fee' || charge.chargeTimeType.value === 'Annual Fee') {
+            @if (showsFeeOnMonthDay(charge)) {
               <span>
                 {{ (charge.feeOnMonthDay | dateFormat) || 'Unassigned' }}
               </span>
             }
-            @if (
-              !(
-                charge.chargeTimeType.value === 'Monthly Fee' ||
-                charge.chargeTimeType.value === 'Annual Fee' ||
-                charge.chargeTimeType.value === 'Specified due date' ||
-                charge.chargeTimeType.value === 'Weekly Fee'
-              )
-            ) {
+            @if (showsPeriodicSummary(charge)) {
+              <span>
+                {{ getPeriodicChargeSummary(charge) }}
+              </span>
+            }
+            @if (!(showsDueDate(charge) || showsFeeOnMonthDay(charge) || showsPeriodicSummary(charge))) {
               <span>
                 {{ 'labels.inputs.N/A' | translate }}
               </span>

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.spec.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.spec.ts
@@ -1,0 +1,74 @@
+import { DecimalPipe } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CdkStepper } from '@angular/cdk/stepper';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import * as solidIcons from '@fortawesome/free-solid-svg-icons';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { LoansAccountPreviewStepComponent } from './loans-account-preview-step.component';
+import { SettingsService } from 'app/settings/settings.service';
+
+describe('LoansAccountPreviewStepComponent', () => {
+  let component: LoansAccountPreviewStepComponent;
+  let fixture: ComponentFixture<LoansAccountPreviewStepComponent>;
+
+  const periodicCharge = {
+    name: 'Insurance Fee',
+    amount: 20,
+    currency: { displaySymbol: '$' },
+    chargeCalculationType: { value: 'Flat' },
+    chargeTimeType: { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' },
+    feeInterval: 1,
+    feeFrequency: { id: 3, code: 'YEARS', value: 'Years' }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        LoansAccountPreviewStepComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: {
+            dateFormat: 'dd MMMM yyyy',
+            language: { code: 'en' },
+            decimals: 2
+          }
+        },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: CdkStepper, useValue: {} },
+        DecimalPipe,
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    const faIconLibrary = TestBed.inject(FaIconLibrary);
+    const iconList = Object.keys(solidIcons)
+      .filter((key) => key !== 'fas' && key !== 'prefix' && key.startsWith('fa'))
+      .map((icon) => (solidIcons as any)[icon]);
+    faIconLibrary.addIcons(...iconList);
+
+    fixture = TestBed.createComponent(LoansAccountPreviewStepComponent);
+    component = fixture.componentInstance;
+    component.loansAccountProductTemplate = {
+      product: { enableDownPayment: false },
+      currency: { code: 'USD' },
+      overdueCharges: [],
+      loanPurposeOptions: []
+    };
+    component.loansAccount = {
+      principalAmount: 100,
+      charges: [periodicCharge]
+    };
+    component.ngOnChanges({} as any);
+    fixture.detectChanges();
+  });
+
+  it('renders a recurrence summary for periodic loan charges in the preview table', () => {
+    expect(fixture.nativeElement.textContent).toContain('Every 1 year, starts on first repayment date');
+  });
+});

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
@@ -24,6 +24,14 @@ import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { FormatNumberPipe } from '../../../pipes/format-number.pipe';
 import { YesnoPipe } from '../../../pipes/yesno.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  formatPeriodicLoanChargeSummary,
+  isAnnualFeeChargeTime,
+  isMonthlyFeeChargeTime,
+  isPeriodicLoanChargeTime,
+  isSpecifiedDueDateChargeTime,
+  isWeeklyFeeChargeTime
+} from 'app/core/utils/charge-time-type';
 
 /**
  * Create Loans Account Preview Step
@@ -117,5 +125,25 @@ export class LoansAccountPreviewStepComponent implements OnChanges {
         .filter((member: any) => member.selected)
         .reduce((acc: number, member: any) => acc + (member.principal ?? 0), 0);
     }
+  }
+
+  showsDueDate(charge: any): boolean {
+    return (
+      isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
+      isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
+      (isPeriodicLoanChargeTime(charge?.chargeTimeType) && !!charge?.dueDate)
+    );
+  }
+
+  showsFeeOnMonthDay(charge: any): boolean {
+    return isMonthlyFeeChargeTime(charge?.chargeTimeType) || isAnnualFeeChargeTime(charge?.chargeTimeType);
+  }
+
+  showsPeriodicSummary(charge: any): boolean {
+    return isPeriodicLoanChargeTime(charge?.chargeTimeType) && !charge?.dueDate;
+  }
+
+  getPeriodicChargeSummary(charge: any): string {
+    return formatPeriodicLoanChargeSummary(charge);
   }
 }

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -1,4 +1,42 @@
 <div class="tab-container">
+  @if (productPeriodicCharges.length) {
+    <section class="product-periodic-charges">
+      <h3>Product periodic charges</h3>
+      <p class="product-periodic-charges__description">
+        These charges are configured on the loan product and materialize on the loan when due.
+      </p>
+
+      <div class="product-periodic-charges__list">
+        @for (charge of productPeriodicCharges; track charge.id) {
+          <article class="product-periodic-charges__item">
+            <div class="product-periodic-charges__row">
+              <span class="product-periodic-charges__label">{{ 'labels.inputs.name' | translate }}</span>
+              <span>{{ charge.name }}</span>
+            </div>
+            <div class="product-periodic-charges__row">
+              <span class="product-periodic-charges__label">{{ 'labels.inputs.Payment due at' | translate }}</span>
+              <span>{{ charge.chargeTimeType?.value || 'Periodic Loan Charge' }}</span>
+            </div>
+            <div class="product-periodic-charges__row">
+              <span class="product-periodic-charges__label">Recurrence</span>
+              <span>{{ charge.recurrenceSummary }}</span>
+            </div>
+            <div class="product-periodic-charges__row">
+              <span class="product-periodic-charges__label">{{ 'labels.inputs.Calculation Type' | translate }}</span>
+              <span>{{ charge.chargeCalculationType?.value || 'N/A' }}</span>
+            </div>
+            <div class="product-periodic-charges__row">
+              <span class="product-periodic-charges__label">{{ 'labels.inputs.Amount' | translate }}</span>
+              <span>
+                {{ charge.amount | currency: productChargeCurrencyCode(charge) : 'symbol-narrow' : '1.2-2' }}
+              </span>
+            </div>
+          </article>
+        }
+      </div>
+    </section>
+  }
+
   <table mat-table [dataSource]="dataSource" matSort>
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.name' | translate }}</th>

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.scss
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.scss
@@ -6,6 +6,46 @@
     margin: 1% auto;
   }
 
+  .product-periodic-charges {
+    margin-bottom: 2rem;
+    padding: 1.25rem;
+    border: 1px solid rgb(0 0 0 / 8%);
+    border-radius: 8px;
+    background: #f7faf7;
+  }
+
+  .product-periodic-charges__description {
+    margin: 0 0 1rem;
+    color: rgb(0 0 0 / 70%);
+  }
+
+  .product-periodic-charges__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .product-periodic-charges__item {
+    display: grid;
+    gap: 0.5rem;
+    padding: 1rem;
+    flex: 1 1 280px;
+    border-radius: 6px;
+    background: #fff;
+    box-shadow: inset 0 0 0 1px rgb(0 0 0 / 6%);
+  }
+
+  .product-periodic-charges__row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .product-periodic-charges__label {
+    color: rgb(0 0 0 / 64%);
+    font-weight: 600;
+  }
+
   table {
     width: 100%;
     margin-top: 3%;

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.spec.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.spec.ts
@@ -1,0 +1,140 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { ChargesTabComponent } from './charges-tab.component';
+import { LoansService } from 'app/loans/loans.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
+import { SystemService } from 'app/system/system.service';
+import { ProductsService } from 'app/products/products.service';
+
+describe('ChargesTabComponent', () => {
+  let component: ChargesTabComponent;
+  let fixture: ComponentFixture<ChargesTabComponent>;
+
+  const loanDetailsData = {
+    id: 16998,
+    clientId: 46614,
+    loanProductId: 81,
+    currency: { code: 'USD' },
+    status: { value: 'Active' },
+    charges: [
+      {
+        id: 13,
+        chargeId: 13,
+        name: 'Admin Fees - 1.9%',
+        penalty: false,
+        paid: false,
+        waived: false,
+        chargePayable: false,
+        amount: 1.99,
+        amountPaid: 0,
+        amountWaived: 0,
+        amountOutstanding: 1.99,
+        currency: { code: 'USD' },
+        dueDate: '2026-03-15',
+        submittedOnDate: '2026-03-15',
+        chargeTimeType: { id: 1, code: 'chargeTimeType.disbursement', value: 'Disbursement' },
+        chargeCalculationType: { value: 'Percentage amount' }
+      }
+    ]
+  };
+
+  const periodicCharge = {
+    id: 21,
+    name: 'Insurance Fee',
+    amount: 10,
+    currency: { code: 'USD' },
+    chargeTimeType: { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' },
+    chargeCalculationType: { value: 'Flat' },
+    feeInterval: 2,
+    feeFrequency: { id: 2, code: 'MONTHS', value: 'Months' }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ChargesTabComponent,
+        TranslateModule.forRoot()
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              data: of({ loanDetailsData })
+            },
+            snapshot: { params: {} }
+          }
+        },
+        {
+          provide: Router,
+          useValue: {
+            url: '/clients/46614/loans-accounts/16998/charges',
+            navigate: jest.fn(),
+            navigateByUrl: jest.fn(() => Promise.resolve(true))
+          }
+        },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: LoansService, useValue: {} },
+        {
+          provide: SettingsService,
+          useValue: {
+            dateFormat: 'dd MMMM yyyy',
+            language: { code: 'en-US' }
+          }
+        },
+        {
+          provide: Dates,
+          useValue: {
+            parseDate: jest.fn((value: string) => new Date(value)),
+            formatDate: jest.fn((value: string) => value)
+          }
+        },
+        {
+          provide: SystemService,
+          useValue: {
+            getConfigurationByName: jest.fn(() => of({ stringValue: 'due-date' }))
+          }
+        },
+        {
+          provide: ProductsService,
+          useValue: {
+            getLoanProduct: jest.fn(() =>
+              of({
+                charges: [
+                  periodicCharge,
+                  {
+                    id: 9,
+                    name: 'Admin Fees - 1.9%',
+                    chargeTimeType: { id: 1, code: 'chargeTimeType.disbursement', value: 'Disbursement' }
+                  }
+                ]
+              })
+            )
+          }
+        },
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChargesTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('shows product periodic charges that are not yet materialized on the loan', () => {
+    expect(component.productPeriodicCharges).toHaveLength(1);
+    expect(fixture.nativeElement.textContent).toContain('Product periodic charges');
+    expect(fixture.nativeElement.textContent).toContain('Insurance Fee');
+    expect(fixture.nativeElement.textContent).toContain('Every 2 months, starts on first repayment date');
+    expect(fixture.nativeElement.textContent).toContain(
+      'These charges are configured on the loan product and materialize on the loan when due.'
+    );
+  });
+});

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -37,8 +37,33 @@ import { GlobalConfiguration } from 'app/system/configurations/global-configurat
 import { TranslateService } from '@ngx-translate/core';
 import { CurrencyPipe } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
+import { catchError, map, of } from 'rxjs';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { formatPeriodicLoanChargeSummary, isPeriodicLoanChargeTime } from 'app/core/utils/charge-time-type';
+import { ProductsService } from 'app/products/products.service';
+
+interface ProductPeriodicChargeView {
+  id: number | string;
+  name: string;
+  amount?: number;
+  currency?: {
+    code?: string;
+  };
+  chargeCalculationType?: {
+    value?: string;
+  };
+  chargeTimeType?: {
+    value?: string;
+  };
+  feeInterval?: number;
+  feeFrequency?: {
+    id?: number;
+    code?: string;
+    value?: string;
+  };
+  recurrenceSummary: string;
+}
 
 @Component({
   selector: 'mifosx-charges-tab',
@@ -73,11 +98,14 @@ export class ChargesTabComponent implements OnInit {
   dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
   private systemService = inject(SystemService);
+  private productsService = inject(ProductsService);
 
   /** Loan Details Data */
   loanDetails: any;
   /** Charges Data */
   chargesData: any;
+  /** Product periodic charges data. */
+  productPeriodicCharges: ProductPeriodicChargeView[] = [];
   /** Status */
   status: any;
   /** Columns to be displayed in charges table. */
@@ -118,7 +146,7 @@ export class ChargesTabComponent implements OnInit {
     this.systemService.getConfigurationByName('charge-accrual-date').subscribe((config: GlobalConfiguration) => {
       this.useDueDate = config.stringValue === 'due-date';
     });
-    this.chargesData = this.loanDetails.charges;
+    this.chargesData = Array.isArray(this.loanDetails?.charges) ? [...this.loanDetails.charges] : [];
     this.status = this.loanDetails.status.value;
     let actionFlag;
     this.chargesData.forEach((element: any) => {
@@ -141,6 +169,7 @@ export class ChargesTabComponent implements OnInit {
     this.dataSource = new MatTableDataSource(this.chargesData);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
+    this.loadProductPeriodicCharges();
   }
 
   /**
@@ -286,5 +315,36 @@ export class ChargesTabComponent implements OnInit {
     this.router
       .navigateByUrl(`/clients/${clientId}/loans-accounts`, { skipLocationChange: true })
       .then(() => this.router.navigate([url]));
+  }
+
+  productChargeCurrencyCode(charge: ProductPeriodicChargeView): string {
+    return charge.currency?.code ?? this.loanDetails?.currency?.code ?? 'USD';
+  }
+
+  private loadProductPeriodicCharges() {
+    const loanProductId = this.loanDetails?.loanProductId ?? this.loanDetails?.productId;
+    if (!loanProductId) {
+      this.productPeriodicCharges = [];
+      return;
+    }
+
+    this.productsService
+      .getLoanProduct(String(loanProductId))
+      .pipe(
+        map((loanProduct: any) =>
+          (loanProduct?.charges ?? [])
+            .filter((charge: any) => isPeriodicLoanChargeTime(charge?.chargeTimeType))
+            .map(
+              (charge: any): ProductPeriodicChargeView => ({
+                ...charge,
+                recurrenceSummary: formatPeriodicLoanChargeSummary(charge)
+              })
+            )
+        ),
+        catchError(() => of([]))
+      )
+      .subscribe((productPeriodicCharges) => {
+        this.productPeriodicCharges = productPeriodicCharges;
+      });
   }
 }

--- a/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts
@@ -14,6 +14,7 @@ import { LoansService } from '../../../loans.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { isSpecifiedDueDateChargeTime } from 'app/core/utils/charge-time-type';
 
 /**
  * Create Add Loan Charge component.
@@ -52,6 +53,7 @@ export class AddLoanChargeComponent implements OnInit {
       value: any;
     };
     chargeTimeType: {
+      code?: string;
       id: number;
       value: any;
     };
@@ -84,7 +86,10 @@ export class AddLoanChargeComponent implements OnInit {
       const chargeDetails = this.loanChargeOptions.find((option) => {
         return option.id === chargeId;
       });
-      if (chargeDetails.chargeTimeType.id === 2) {
+      if (!chargeDetails) {
+        return;
+      }
+      if (isSpecifiedDueDateChargeTime(chargeDetails.chargeTimeType)) {
         this.loanChargeForm.addControl('dueDate', new UntypedFormControl('', Validators.required));
       } else {
         this.loanChargeForm.removeControl('dueDate');

--- a/src/app/loans/loans.service.spec.ts
+++ b/src/app/loans/loans.service.spec.ts
@@ -1,0 +1,111 @@
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { LoansService } from './loans.service';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+
+describe('LoansService', () => {
+  let service: LoansService;
+  let mockDateUtils: { formatDate: jest.Mock };
+
+  beforeEach(() => {
+    mockDateUtils = {
+      formatDate: jest.fn((value: any) => `formatted:${value}`)
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        LoansService,
+        { provide: HttpClient, useValue: {} },
+        { provide: Dates, useValue: mockDateUtils },
+        {
+          provide: SettingsService,
+          useValue: {
+            dateFormat: 'dd MMMM yyyy',
+            language: { code: 'en' },
+            businessDate: '2026-03-15'
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(LoansService);
+  });
+
+  it('filters periodic loan charges out of manual loan charge submissions', () => {
+    const periodicCharge = {
+      chargeId: 21,
+      amount: 10,
+      chargeTimeType: {
+        id: 17,
+        code: 'chargeTimeType.loanPeriodic',
+        value: 'Periodic Loan Charge'
+      }
+    };
+    const disbursementCharge = {
+      chargeId: 13,
+      amount: 1.99,
+      chargeTimeType: {
+        id: 1,
+        code: 'chargeTimeType.disbursement',
+        value: 'Disbursement'
+      }
+    };
+
+    expect(
+      service.filterManualLoanCharges([
+        disbursementCharge,
+        periodicCharge
+      ])
+    ).toEqual([disbursementCharge]);
+  });
+
+  it('omits periodic loan charges when building the loan request payload', () => {
+    const payload = service.buildLoanRequestPayload(
+      {
+        charges: [
+          {
+            chargeId: 13,
+            amount: 1.99,
+            dueDate: '2026-03-20',
+            chargeTimeType: {
+              id: 2,
+              code: 'chargeTimeType.specifiedDueDate',
+              value: 'Specified due date'
+            }
+          },
+          {
+            chargeId: 21,
+            amount: 10,
+            chargeTimeType: {
+              id: 17,
+              code: 'chargeTimeType.loanPeriodic',
+              value: 'Periodic Loan Charge'
+            }
+          }
+        ],
+        disbursementData: [],
+        interestChargedFromDate: '2026-03-15',
+        repaymentsStartingFromDate: '2026-04-15',
+        submittedOnDate: '2026-03-15',
+        expectedDisbursementDate: '2026-03-15',
+        principalAmount: 1000,
+        interestCalculationPeriodType: 1,
+        allowPartialPeriodInterestCalculation: true,
+        multiDisburseLoan: false
+      },
+      { clientId: 1 },
+      [],
+      'en',
+      'dd MMMM yyyy'
+    );
+
+    expect(payload.charges).toEqual([
+      {
+        chargeId: 13,
+        amount: 1.99,
+        dueDate: 'formatted:2026-03-20'
+      }
+    ]);
+  });
+});

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -8,6 +8,7 @@ import { map } from 'rxjs/operators';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { DisbursementData } from './models/loan-account.model';
+import { isPeriodicLoanChargeTime } from 'app/core/utils/charge-time-type';
 
 interface StandingInstructionsResponse {
   pageItems: any[];
@@ -701,7 +702,7 @@ export class LoansService {
   ): any {
     const loansAccountData = {
       ...loansAccount,
-      charges: (loansAccount.charges ?? [])
+      charges: this.filterManualLoanCharges(loansAccount.charges ?? [])
         .map((charge: any) => {
           const chargeId = charge.chargeId ?? charge.id;
           if (chargeId == null) {
@@ -788,6 +789,10 @@ export class LoansService {
     loansAccountData.allowPartialPeriodInterestCalcualtion = loansAccountData.allowPartialPeriodInterestCalculation;
     delete loansAccountData.allowPartialPeriodInterestCalculation;
     return loansAccountData;
+  }
+
+  filterManualLoanCharges<T extends { chargeTimeType?: any }>(charges: T[] = []): T[] {
+    return (charges ?? []).filter((charge) => !!charge && !isPeriodicLoanChargeTime(charge.chargeTimeType));
   }
 
   saveLoanDisbursementDetailsData(disbursementData: DisbursementData[]): void {

--- a/src/app/products/charges/create-charge/create-charge.component.html
+++ b/src/app/products/charges/create-charge/create-charge.component.html
@@ -100,14 +100,14 @@
                   }
                 </mat-form-field>
               }
-              @if (chargeForm.controls.chargeTimeType.value === 9) {
+              @if (isOverdueChargeTimeSelected()) {
                 <div class="flex-48 add-fee-frequency-wrapper">
                   <mat-checkbox labelPosition="before" formControlName="addFeeFrequency">
                     {{ 'labels.inputs.Add Fee Frequency' | translate }}
                   </mat-checkbox>
                 </div>
               }
-              @if (chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value) {
+              @if (isOverdueChargeTimeSelected() && chargeForm.controls.addFeeFrequency?.value) {
                 <mat-form-field class="flex-48">
                   <mat-label>{{ 'labels.inputs.Frequency Interval' | translate }}</mat-label>
                   <input matInput required formControlName="feeInterval" />
@@ -125,11 +125,47 @@
                   }
                 </mat-form-field>
               }
-              @if (chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value) {
+              @if (isOverdueChargeTimeSelected() && chargeForm.controls.addFeeFrequency?.value) {
                 <mat-form-field class="flex-48">
                   <mat-label>{{ 'labels.inputs.Charge Frequency' | translate }}</mat-label>
                   <mat-select required formControlName="feeFrequency">
                     @for (feeFrequency of chargesTemplateData.feeFrequencyOptions; track feeFrequency) {
+                      <mat-option [value]="feeFrequency.id">
+                        {{ feeFrequency.value | translateKey: 'catalogs' }}
+                      </mat-option>
+                    }
+                  </mat-select>
+                  @if (chargeForm.controls.feeFrequency.hasError('required')) {
+                    <mat-error>
+                      {{ 'labels.inputs.Charge Frequency' | translate }} {{ 'labels.commons.is' | translate }}
+                      <strong>{{ 'labels.commons.required' | translate }}</strong>
+                    </mat-error>
+                  }
+                </mat-form-field>
+              }
+              @if (isPeriodicChargeTimeSelected()) {
+                <mat-form-field class="flex-48">
+                  <mat-label>{{ 'labels.inputs.Frequency Interval' | translate }}</mat-label>
+                  <input matInput required formControlName="feeInterval" />
+                  @if (chargeForm.controls.feeInterval.hasError('required')) {
+                    <mat-error>
+                      {{ 'labels.inputs.Frequency Interval' | translate }} {{ 'labels.commons.is' | translate }}
+                      <strong>{{ 'labels.commons.required' | translate }}</strong>
+                    </mat-error>
+                  }
+                  @if (chargeForm.controls.feeInterval.hasError('pattern')) {
+                    <mat-error>
+                      {{ 'labels.inputs.Frequency Interval' | translate }}
+                      <strong>{{ 'labels.commons.must be a positive integer' | translate }}</strong>
+                    </mat-error>
+                  }
+                </mat-form-field>
+              }
+              @if (isPeriodicChargeTimeSelected()) {
+                <mat-form-field class="flex-48">
+                  <mat-label>{{ 'labels.inputs.Charge Frequency' | translate }}</mat-label>
+                  <mat-select required formControlName="feeFrequency">
+                    @for (feeFrequency of periodicFeeFrequencyOptions; track feeFrequency) {
                       <mat-option [value]="feeFrequency.id">
                         {{ feeFrequency.value | translateKey: 'catalogs' }}
                       </mat-option>

--- a/src/app/products/charges/create-charge/create-charge.component.spec.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.spec.ts
@@ -1,0 +1,127 @@
+import { DatePipe } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { CreateChargeComponent } from './create-charge.component';
+import { ProductsService } from '../../products.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+
+describe('CreateChargeComponent', () => {
+  let component: CreateChargeComponent;
+  let fixture: ComponentFixture<CreateChargeComponent>;
+
+  const mockChargesTemplate: any = {
+    chargeAppliesToOptions: [
+      { id: 1, value: 'Loan' }],
+    currencyOptions: [
+      { code: 'USD', name: 'US Dollar', decimalPlaces: 2 }],
+    loanChargeTimeTypeOptions: [
+      { id: 9, code: 'chargeTimeType.overdueInstallment', value: 'Overdue Installment' },
+      { id: 12, code: 'chargeTimeType.trancheDisbursement', value: 'Tranche Disbursement' },
+      { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' }
+    ],
+    savingsChargeTimeTypeOptions: [],
+    clientChargeTimeTypeOptions: [],
+    shareChargeTimeTypeOptions: [],
+    loanChargeCalculationTypeOptions: [
+      { id: 1, value: 'Flat' },
+      { id: 5, value: '% of disbursement amount' }
+    ],
+    savingsChargeCalculationTypeOptions: [],
+    clientChargeCalculationTypeOptions: [],
+    shareChargeCalculationTypeOptions: [],
+    chargePaymetModeOptions: [
+      { id: 0, value: 'Regular' }],
+    feeFrequencyOptions: [
+      { id: 0, code: 'DAYS', value: 'Days' },
+      { id: 1, code: 'WEEKS', value: 'Weeks' },
+      { id: 2, code: 'MONTHS', value: 'Months' },
+      { id: 3, code: 'YEARS', value: 'Years' }
+    ],
+    taxGroupOptions: [],
+    incomeOrLiabilityAccountOptions: {
+      incomeAccountOptions: [],
+      liabilityAccountOptions: []
+    }
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        CreateChargeComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({ chargesTemplate: mockChargesTemplate })
+          }
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: ProductsService, useValue: { createCharge: jest.fn(() => of({})) } },
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' }
+          }
+        },
+        {
+          provide: AuthenticationService,
+          useValue: {
+            getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] })
+          }
+        },
+        DatePipe,
+        provideNativeDateAdapter(),
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateChargeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('adds required periodic recurrence controls when periodic loan charge is selected', () => {
+    component.chargeForm.patchValue({
+      chargeAppliesTo: 1,
+      chargeTimeType: 17
+    });
+
+    expect(component.chargeForm.contains('feeFrequency')).toBe(true);
+    expect(component.chargeForm.contains('feeInterval')).toBe(true);
+    expect(component.chargeForm.controls.feeFrequency.hasError('required')).toBe(true);
+    expect(component.chargeForm.controls.feeInterval.hasError('required')).toBe(true);
+  });
+
+  it('does not add feeOnMonthDay when periodic loan charge is selected', () => {
+    component.chargeForm.patchValue({
+      chargeAppliesTo: 1,
+      chargeTimeType: 17
+    });
+
+    expect(component.chargeForm.contains('feeOnMonthDay')).toBe(false);
+  });
+
+  it('filters periodic charge frequency options down to weeks, months, and years', () => {
+    expect(component.periodicFeeFrequencyOptions.map((option) => option.code)).toEqual([
+      'WEEKS',
+      'MONTHS',
+      'YEARS'
+    ]);
+  });
+
+  it('keeps disbursement-percentage calculation unavailable for periodic loan charges', () => {
+    component.chargeForm.patchValue({
+      chargeAppliesTo: 1,
+      chargeTimeType: 17
+    });
+
+    expect(component.filteredChargeCalculationType()).toEqual([{ id: 1, value: 'Flat' }]);
+  });
+});

--- a/src/app/products/charges/create-charge/create-charge.component.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.ts
@@ -20,6 +20,16 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { ValidateOnFocusDirective } from '../../../directives/validate-on-focus.directive';
 import { GlAccountSelectorComponent } from '../../../shared/accounting/gl-account-selector/gl-account-selector.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  filterPeriodicFeeFrequencyOptions,
+  isAnnualFeeChargeTime,
+  isMonthlyFeeChargeTime,
+  isOverdueInstallmentChargeTime,
+  isPeriodicLoanChargeTime,
+  isTrancheDisbursementChargeTime,
+  isWeeklyFeeChargeTime,
+  resolveChargeTimeTypeOption
+} from 'app/core/utils/charge-time-type';
 
 /**
  * Create charge component.
@@ -170,25 +180,21 @@ export class CreateChargeComponent implements OnInit {
    * @returns {any} Filtered charge calculation type data.
    */
   filteredChargeCalculationType(): any {
+    const chargeTimeType = this.getSelectedChargeTimeTypeOption();
+
     return this.chargeCalculationTypeData.filter((chargeCalculationType: any) => {
       if (
-        this.chargeForm.get('chargeTimeType').value === 12 &&
+        isTrancheDisbursementChargeTime(chargeTimeType) &&
         (chargeCalculationType.id === 3 || chargeCalculationType.id === 4)
       ) {
         return false;
       }
-      if (this.chargeForm.get('chargeTimeType').value !== 12 && chargeCalculationType.id === 5) {
+      if (!isTrancheDisbursementChargeTime(chargeTimeType) && chargeCalculationType.id === 5) {
         return false;
       }
       if (this.chargeForm.get('chargeAppliesTo').value === 2) {
-        if (
-          !(
-            this.chargeForm.get('chargeTimeType').value === 5 ||
-            this.chargeForm.get('chargeTimeType').value === 16 ||
-            this.chargeForm.get('chargeTimeType').value === 17
-          ) &&
-          chargeCalculationType.id === 2
-        ) {
+        const selectedChargeTimeTypeId = this.chargeForm.get('chargeTimeType').value;
+        if (!(selectedChargeTimeTypeId === 5 || selectedChargeTimeTypeId === 16) && chargeCalculationType.id === 2) {
           return false;
         }
       }
@@ -250,55 +256,74 @@ export class CreateChargeComponent implements OnInit {
       this.chargeForm.removeControl('feeInterval');
       this.chargeForm.removeControl('feeOnMonthDay');
       this.chargeForm.removeControl('addFeeFrequency');
+      this.repeatEveryLabel = '';
       if (this.chargeForm.get('chargeAppliesTo').value !== 4) {
         this.chargeForm.get('penalty').enable();
       }
-      switch (chargeTimeType) {
-        case 6: // Annual Fee
-          this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl('', Validators.required));
-          break;
-        case 7: // Monthly Fee
-          this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl(''));
-          this.chargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl('', [
-              Validators.required,
-              Validators.min(1),
-              Validators.max(12),
-              Validators.pattern('^[1-9]\\d*$')
-            ])
-          );
-          this.repeatEveryLabel = 'Months';
-          break;
-        case 9: // Overdue Fee
-          this.chargeForm.get('penalty').setValue(true);
-          this.chargeForm.addControl('addFeeFrequency', new UntypedFormControl(false));
-          this.chargeForm.get('addFeeFrequency').valueChanges.subscribe((addFeeFrequency) => {
-            if (addFeeFrequency) {
-              this.chargeForm.addControl('feeFrequency', new UntypedFormControl('', Validators.required));
-              this.chargeForm.addControl(
-                'feeInterval',
-                new UntypedFormControl('', [
-                  Validators.required,
-                  Validators.pattern('^[1-9]\\d*$')
-                ])
-              );
-            } else {
-              this.chargeForm.removeControl('feeFrequency');
-              this.chargeForm.removeControl('feeInterval');
-            }
-          });
-          break;
-        case 11: // Weekly Fee
-          this.chargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl('', [
-              Validators.required,
-              Validators.pattern('^[1-9]\\d*$')
-            ])
-          );
-          this.repeatEveryLabel = 'Weeks';
-          break;
+      const selectedChargeTimeType = this.getChargeTimeTypeOption(chargeTimeType);
+
+      if (isAnnualFeeChargeTime(selectedChargeTimeType)) {
+        this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl('', Validators.required));
+        return;
+      }
+
+      if (isMonthlyFeeChargeTime(selectedChargeTimeType)) {
+        this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl(''));
+        this.chargeForm.addControl(
+          'feeInterval',
+          new UntypedFormControl('', [
+            Validators.required,
+            Validators.min(1),
+            Validators.max(12),
+            Validators.pattern('^[1-9]\\d*$')
+          ])
+        );
+        this.repeatEveryLabel = 'Months';
+        return;
+      }
+
+      if (isOverdueInstallmentChargeTime(selectedChargeTimeType)) {
+        this.chargeForm.get('penalty').setValue(true);
+        this.chargeForm.addControl('addFeeFrequency', new UntypedFormControl(false));
+        this.chargeForm.get('addFeeFrequency').valueChanges.subscribe((addFeeFrequency) => {
+          if (addFeeFrequency) {
+            this.chargeForm.addControl('feeFrequency', new UntypedFormControl('', Validators.required));
+            this.chargeForm.addControl(
+              'feeInterval',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.pattern('^[1-9]\\d*$')
+              ])
+            );
+          } else {
+            this.chargeForm.removeControl('feeFrequency');
+            this.chargeForm.removeControl('feeInterval');
+          }
+        });
+        return;
+      }
+
+      if (isPeriodicLoanChargeTime(selectedChargeTimeType)) {
+        this.chargeForm.addControl('feeFrequency', new UntypedFormControl('', Validators.required));
+        this.chargeForm.addControl(
+          'feeInterval',
+          new UntypedFormControl('', [
+            Validators.required,
+            Validators.pattern('^[1-9]\\d*$')
+          ])
+        );
+        return;
+      }
+
+      if (isWeeklyFeeChargeTime(selectedChargeTimeType)) {
+        this.chargeForm.addControl(
+          'feeInterval',
+          new UntypedFormControl('', [
+            Validators.required,
+            Validators.pattern('^[1-9]\\d*$')
+          ])
+        );
+        this.repeatEveryLabel = 'Weeks';
       }
     });
     this.chargeForm.get('currencyCode').valueChanges.subscribe((currencyCode) => {
@@ -338,5 +363,25 @@ export class CreateChargeComponent implements OnInit {
     this.productsService.createCharge(data).subscribe((response: any) => {
       this.router.navigate(['../'], { relativeTo: this.route });
     });
+  }
+
+  get periodicFeeFrequencyOptions(): any[] {
+    return filterPeriodicFeeFrequencyOptions(this.chargesTemplateData?.feeFrequencyOptions);
+  }
+
+  isOverdueChargeTimeSelected(): boolean {
+    return isOverdueInstallmentChargeTime(this.getSelectedChargeTimeTypeOption());
+  }
+
+  isPeriodicChargeTimeSelected(): boolean {
+    return isPeriodicLoanChargeTime(this.getSelectedChargeTimeTypeOption());
+  }
+
+  private getSelectedChargeTimeTypeOption() {
+    return this.getChargeTimeTypeOption(this.chargeForm.get('chargeTimeType').value);
+  }
+
+  private getChargeTimeTypeOption(chargeTimeTypeId: number | null | undefined) {
+    return resolveChargeTimeTypeOption(this.chargeTimeTypeData, chargeTimeTypeId);
   }
 }

--- a/src/app/products/charges/edit-charge/edit-charge.component.html
+++ b/src/app/products/charges/edit-charge/edit-charge.component.html
@@ -64,7 +64,7 @@
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Charge Calculation' | translate }}</mat-label>
             <mat-select required formControlName="chargeCalculationType">
-              @for (chargeCalculation of chargeCalculationTypeOptions; track chargeCalculation) {
+              @for (chargeCalculation of filteredChargeCalculationType(); track chargeCalculation) {
                 <mat-option [value]="chargeCalculation.id">
                   {{ chargeCalculation.value | translateKey: 'catalogs' }}
                 </mat-option>
@@ -174,11 +174,11 @@
             }
           </mat-form-field>
 
-          @if (addFeeFrequency) {
+          @if (isOverdueChargeTimeSelected()) {
             <div class="password-never-expires-wrapper checkbox flex-48">
               <mat-checkbox
                 labelPosition="before"
-                [checked]="addFeeFrequency && showFeeOptions"
+                [checked]="showFeeOptions"
                 (change)="getFeeFrequency($event.checked)"
               >
                 {{ 'labels.inputs.Add Fee Frequency' | translate }}
@@ -186,7 +186,7 @@
             </div>
           }
 
-          @if (addFeeFrequency && showFeeOptions) {
+          @if (showFeeOptions) {
             <mat-form-field class="flex-48">
               <mat-label>{{ 'labels.inputs.Frequency Interval' | translate }}</mat-label>
               <input matInput required autofocus type="text" formControlName="feeInterval" />
@@ -196,14 +196,25 @@
                   <strong>{{ 'labels.commons.required' | translate }}</strong>
                 </mat-error>
               }
+              @if (chargeForm.controls.feeInterval.hasError('pattern')) {
+                <mat-error>
+                  {{ 'labels.inputs.Frequency Interval' | translate }}
+                  <strong>{{ 'labels.commons.must be a positive integer' | translate }}</strong>
+                </mat-error>
+              }
             </mat-form-field>
           }
 
-          @if (addFeeFrequency && showFeeOptions) {
+          @if (showFeeOptions) {
             <mat-form-field class="flex-48">
               <mat-label>{{ 'labels.inputs.Charge Frequency' | translate }}</mat-label>
               <mat-select required formControlName="feeFrequency">
-                @for (chargeFrequency of chargeData.feeFrequencyOptions; track chargeFrequency) {
+                @for (
+                  chargeFrequency of isPeriodicChargeTimeSelected()
+                    ? periodicFeeFrequencyOptions
+                    : chargeData.feeFrequencyOptions;
+                  track chargeFrequency
+                ) {
                   <mat-option [value]="chargeFrequency.id">
                     {{ chargeFrequency.value | translateKey: 'catalogs' }}
                   </mat-option>

--- a/src/app/products/charges/edit-charge/edit-charge.component.spec.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { EditChargeComponent } from './edit-charge.component';
+import { ProductsService } from 'app/products/products.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+
+describe('EditChargeComponent', () => {
+  let component: EditChargeComponent;
+  let fixture: ComponentFixture<EditChargeComponent>;
+
+  const mockChargeTemplate: any = {
+    id: 42,
+    name: 'Insurance Fee',
+    active: true,
+    penalty: false,
+    amount: 25,
+    currency: { code: 'USD', name: 'US Dollar' },
+    chargeAppliesTo: { id: 1, value: 'Loan' },
+    chargeTimeType: { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' },
+    chargeCalculationType: { id: 1, value: 'Flat' },
+    chargePaymentMode: { id: 0, value: 'Regular' },
+    feeInterval: 1,
+    feeFrequency: { id: 3, code: 'YEARS', value: 'Years' },
+    taxGroupOptions: [],
+    loanChargeTimeTypeOptions: [
+      { id: 9, code: 'chargeTimeType.overdueInstallment', value: 'Overdue Installment' },
+      { id: 12, code: 'chargeTimeType.trancheDisbursement', value: 'Tranche Disbursement' },
+      { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' }
+    ],
+    loanChargeCalculationTypeOptions: [
+      { id: 1, value: 'Flat' },
+      { id: 5, value: '% of disbursement amount' }
+    ],
+    feeFrequencyOptions: [
+      { id: 0, code: 'DAYS', value: 'Days' },
+      { id: 1, code: 'WEEKS', value: 'Weeks' },
+      { id: 2, code: 'MONTHS', value: 'Months' },
+      { id: 3, code: 'YEARS', value: 'Years' }
+    ],
+    currencyOptions: [
+      { code: 'USD', name: 'US Dollar' }]
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        EditChargeComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({ chargesTemplate: mockChargeTemplate })
+          }
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: ProductsService, useValue: { updateCharge: jest.fn(() => of({})) } },
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' }
+          }
+        },
+        {
+          provide: AuthenticationService,
+          useValue: {
+            getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] })
+          }
+        },
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditChargeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('shows periodic recurrence controls for periodic loan charges', () => {
+    expect(component.isPeriodicChargeTimeSelected()).toBe(true);
+    expect(component.showFeeOptions).toBe(true);
+    expect(component.addFeeFrequency).toBe(false);
+    expect(component.chargeForm.controls.feeInterval.value).toBe(1);
+    expect(component.chargeForm.controls.feeFrequency.value).toBe(3);
+  });
+
+  it('filters periodic frequency options to supported recurrence units only', () => {
+    expect(component.periodicFeeFrequencyOptions.map((option) => option.code)).toEqual([
+      'WEEKS',
+      'MONTHS',
+      'YEARS'
+    ]);
+  });
+
+  it('keeps disbursement-percentage calculation unavailable for periodic loan charges', () => {
+    expect(component.filteredChargeCalculationType()).toEqual([{ id: 1, value: 'Flat' }]);
+  });
+});

--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -12,6 +12,13 @@ import { ValidateOnFocusDirective } from '../../../directives/validate-on-focus.
 import { GlAccountSelectorComponent } from '../../../shared/accounting/gl-account-selector/gl-account-selector.component';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  filterPeriodicFeeFrequencyOptions,
+  isOverdueInstallmentChargeTime,
+  isPeriodicLoanChargeTime,
+  isTrancheDisbursementChargeTime,
+  resolveChargeTimeTypeOption
+} from 'app/core/utils/charge-time-type';
 
 /**
  * Edit Charge component.
@@ -80,8 +87,6 @@ export class EditChargeComponent {
    * Edit Charge form.
    */
   editChargeForm() {
-    this.showFeeOptions = this.chargeData.feeInterval && this.chargeData.feeInterval > 0;
-
     this.chargeForm = this.formBuilder.group({
       name: [
         this.chargeData.name,
@@ -122,19 +127,15 @@ export class EditChargeComponent {
       case 'Loan': {
         this.chargeTimeTypeOptions = this.chargeData.loanChargeTimeTypeOptions;
         this.chargeCalculationTypeOptions = this.chargeData.loanChargeCalculationTypeOptions;
-        this.addFeeFrequency = true;
         this.chargePaymentMode = true;
         this.chargeForm.addControl(
           'chargePaymentMode',
           this.formBuilder.control(this.chargeData.chargePaymentMode.id, Validators.required)
         );
-        if (this.showFeeOptions) {
-          this.getFeeFrequency(this.showFeeOptions);
-          this.chargeForm.patchValue({
-            feeInterval: this.chargeData.feeInterval,
-            feeFrequency: this.chargeData.feeFrequency.id
-          });
-        }
+        this.configureRecurringFeeControls(this.chargeData.chargeTimeType.id);
+        this.chargeForm.get('chargeTimeType').valueChanges.subscribe((chargeTimeTypeId) => {
+          this.configureRecurringFeeControls(chargeTimeTypeId);
+        });
         break;
       }
       case 'Savings': {
@@ -179,7 +180,13 @@ export class EditChargeComponent {
   getFeeFrequency(isChecked: boolean) {
     this.showFeeOptions = isChecked;
     if (isChecked) {
-      this.chargeForm.addControl('feeInterval', this.formBuilder.control('', Validators.required));
+      this.chargeForm.addControl(
+        'feeInterval',
+        this.formBuilder.control('', [
+          Validators.required,
+          Validators.pattern('^[1-9]\\d*$')
+        ])
+      );
       this.chargeForm.addControl('feeFrequency', this.formBuilder.control('', Validators.required));
     } else {
       this.chargeForm.removeControl('feeInterval');
@@ -227,5 +234,84 @@ export class EditChargeComponent {
     this.productsService.updateCharge(this.chargeData.id.toString(), charges).subscribe((response: any) => {
       this.router.navigate(['../'], { relativeTo: this.route });
     });
+  }
+
+  filteredChargeCalculationType(): any {
+    const chargeTimeType = this.getSelectedChargeTimeTypeOption();
+
+    return this.chargeCalculationTypeOptions.filter((chargeCalculationType: any) => {
+      if (
+        isTrancheDisbursementChargeTime(chargeTimeType) &&
+        (chargeCalculationType.id === 3 || chargeCalculationType.id === 4)
+      ) {
+        return false;
+      }
+
+      if (!isTrancheDisbursementChargeTime(chargeTimeType) && chargeCalculationType.id === 5) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  get periodicFeeFrequencyOptions(): any[] {
+    return filterPeriodicFeeFrequencyOptions(this.chargeData?.feeFrequencyOptions);
+  }
+
+  isOverdueChargeTimeSelected(): boolean {
+    return isOverdueInstallmentChargeTime(this.getSelectedChargeTimeTypeOption());
+  }
+
+  isPeriodicChargeTimeSelected(): boolean {
+    return isPeriodicLoanChargeTime(this.getSelectedChargeTimeTypeOption());
+  }
+
+  private configureRecurringFeeControls(chargeTimeTypeId: number | null | undefined) {
+    const chargeTimeType = this.getChargeTimeTypeOption(chargeTimeTypeId);
+    const existingFeeInterval = this.chargeForm.get('feeInterval')?.value ?? this.chargeData.feeInterval ?? '';
+    const existingFeeFrequency = this.chargeForm.get('feeFrequency')?.value ?? this.chargeData.feeFrequency?.id ?? '';
+
+    this.chargeForm.removeControl('feeInterval');
+    this.chargeForm.removeControl('feeFrequency');
+    this.showFeeOptions = false;
+    this.addFeeFrequency = false;
+
+    if (isPeriodicLoanChargeTime(chargeTimeType)) {
+      this.showFeeOptions = true;
+      this.chargeForm.addControl(
+        'feeInterval',
+        this.formBuilder.control(existingFeeInterval, [
+          Validators.required,
+          Validators.pattern('^[1-9]\\d*$')
+        ])
+      );
+      this.chargeForm.addControl('feeFrequency', this.formBuilder.control(existingFeeFrequency, Validators.required));
+      return;
+    }
+
+    if (isOverdueInstallmentChargeTime(chargeTimeType)) {
+      this.addFeeFrequency = true;
+      const hasExistingRecurringConfig = !!existingFeeInterval && !!existingFeeFrequency;
+      this.showFeeOptions = hasExistingRecurringConfig;
+      if (this.showFeeOptions) {
+        this.chargeForm.addControl(
+          'feeInterval',
+          this.formBuilder.control(existingFeeInterval, [
+            Validators.required,
+            Validators.pattern('^[1-9]\\d*$')
+          ])
+        );
+        this.chargeForm.addControl('feeFrequency', this.formBuilder.control(existingFeeFrequency, Validators.required));
+      }
+    }
+  }
+
+  private getSelectedChargeTimeTypeOption() {
+    return this.getChargeTimeTypeOption(this.chargeForm.controls.chargeTimeType.value);
+  }
+
+  private getChargeTimeTypeOption(chargeTimeTypeId: number | null | undefined) {
+    return resolveChargeTimeTypeOption(this.chargeTimeTypeOptions, chargeTimeTypeId);
   }
 }

--- a/src/app/products/charges/models/charge.model.ts
+++ b/src/app/products/charges/models/charge.model.ts
@@ -37,6 +37,7 @@ export enum ChargeAppliesToCode {
   ChargeTimeTypeAnnualFee = 'chargeTimeType.annualFee',
   ChargeTimeTypeDisbursement = 'chargeTimeType.disbursement',
   ChargeTimeTypeInstalmentFee = 'chargeTimeType.instalmentFee',
+  ChargeTimeTypeLoanPeriodic = 'chargeTimeType.loanPeriodic',
   ChargeTimeTypeMonthlyFee = 'chargeTimeType.monthlyFee',
   ChargeTimeTypeOverdueInstallment = 'chargeTimeType.overdueInstallment',
   ChargeTimeTypeSavingsActivation = 'chargeTimeType.savingsActivation',

--- a/src/app/products/charges/view-charge/view-charge.component.html
+++ b/src/app/products/charges/view-charge/view-charge.component.html
@@ -109,25 +109,25 @@
           {{ chargeData.active === true | yesNo }}
         </div>
 
-        @if (chargeData.chargeTimeType.id === 9 && chargeData.feeFrequency) {
+        @if (showRecurringFeeDetails() && chargeData.feeFrequency) {
           <div class="flex-50 mat-body-strong">
             {{ 'labels.inputs.Add Fee Frequency' | translate }}
           </div>
         }
 
-        @if (chargeData.chargeTimeType.id === 9 && chargeData.feeFrequency && chargeData.feeFrequency) {
+        @if (showRecurringFeeDetails() && chargeData.feeFrequency && chargeData.feeFrequency) {
           <div class="flex-50">
             {{ chargeData.feeFrequency.value | translateKey: 'catalogs' }}
           </div>
         }
 
-        @if (chargeData.chargeTimeType.id === 9 && chargeData.feeInterval) {
+        @if (showRecurringFeeDetails() && chargeData.feeInterval) {
           <div class="flex-50 mat-body-strong">
             {{ 'labels.inputs.Frequency Interval' | translate }}
           </div>
         }
 
-        @if (chargeData.chargeTimeType.id === 9 && chargeData.feeInterval) {
+        @if (showRecurringFeeDetails() && chargeData.feeInterval) {
           <div class="flex-50">
             {{ chargeData.feeInterval }}
           </div>

--- a/src/app/products/charges/view-charge/view-charge.component.spec.ts
+++ b/src/app/products/charges/view-charge/view-charge.component.spec.ts
@@ -1,0 +1,61 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { ViewChargeComponent } from './view-charge.component';
+import { ProductsService } from 'app/products/products.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+
+describe('ViewChargeComponent', () => {
+  let component: ViewChargeComponent;
+  let fixture: ComponentFixture<ViewChargeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ViewChargeComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              charge: {
+                id: 9,
+                chargeTimeType: { id: 17, code: 'chargeTimeType.loanPeriodic', value: 'Periodic Loan Charge' },
+                feeInterval: 1,
+                feeFrequency: { id: 3, code: 'YEARS', value: 'Years' }
+              }
+            })
+          }
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: ProductsService, useValue: { deleteCharge: jest.fn(() => of({})) } },
+        {
+          provide: AuthenticationService,
+          useValue: {
+            getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] })
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ViewChargeComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('shows recurring fee details for periodic loan charges', () => {
+    expect(component.showRecurringFeeDetails()).toBe(true);
+  });
+
+  it('does not show recurring fee details for non-recurring charge times', () => {
+    component.chargeData = {
+      chargeTimeType: { id: 1, code: 'chargeTimeType.disbursement', value: 'Disbursement' }
+    };
+
+    expect(component.showRecurringFeeDetails()).toBe(false);
+  });
+});

--- a/src/app/products/charges/view-charge/view-charge.component.ts
+++ b/src/app/products/charges/view-charge/view-charge.component.ts
@@ -13,6 +13,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { GlAccountDisplayComponent } from '../../../shared/accounting/gl-account-display/gl-account-display.component';
 import { YesnoPipe } from '../../../pipes/yesno.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { isOverdueInstallmentChargeTime, isPeriodicLoanChargeTime } from 'app/core/utils/charge-time-type';
 
 /**
  * View Charge Component.
@@ -74,5 +75,12 @@ export class ViewChargeComponent {
         });
       }
     });
+  }
+
+  showRecurringFeeDetails(): boolean {
+    return (
+      isOverdueInstallmentChargeTime(this.chargeData?.chargeTimeType) ||
+      isPeriodicLoanChargeTime(this.chargeData?.chargeTimeType)
+    );
   }
 }

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -607,6 +607,7 @@
       "Withdrawal Fee": "Withdrawal Fee",
       "Annual Fee": "Annual Fee",
       "Monthly Fee": "Monthly Fee",
+      "Periodic Loan Charge": "Periodic Loan Charge",
       "Weekly Fee": "Weekly Fee",
       "Share Account Activate": "Share Account Activate",
       "Share Purchase": "Share Purchase",


### PR DESCRIPTION
## Summary
- add shared charge-time helpers so Mifos can detect `chargeTimeType.loanPeriodic` by code, id, or legacy value
- support periodic recurrence configuration in the charge create, edit, and view flows using `feeFrequency` and `feeInterval`
- show a recurrence summary for pre-materialized periodic loan charges in loan stepper and preview screens, while keeping them non-date-editable
- add targeted Jest coverage for the new helper and the affected charge and loan UI components

## Testing
- `npx prettier --check src/app/core/utils/charge-time-type.spec.ts src/app/core/utils/charge-time-type.ts src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.spec.ts src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts src/app/products/charges/create-charge/create-charge.component.html src/app/products/charges/create-charge/create-charge.component.spec.ts src/app/products/charges/create-charge/create-charge.component.ts src/app/products/charges/edit-charge/edit-charge.component.html src/app/products/charges/edit-charge/edit-charge.component.spec.ts src/app/products/charges/edit-charge/edit-charge.component.ts src/app/products/charges/models/charge.model.ts src/app/products/charges/view-charge/view-charge.component.html src/app/products/charges/view-charge/view-charge.component.spec.ts src/app/products/charges/view-charge/view-charge.component.ts src/assets/translations/en-US.json`
- `npx eslint src/app/core/utils/charge-time-type.spec.ts src/app/core/utils/charge-time-type.ts src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.spec.ts src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts src/app/products/charges/create-charge/create-charge.component.spec.ts src/app/products/charges/create-charge/create-charge.component.ts src/app/products/charges/edit-charge/edit-charge.component.spec.ts src/app/products/charges/edit-charge/edit-charge.component.ts src/app/products/charges/models/charge.model.ts src/app/products/charges/view-charge/view-charge.component.spec.ts src/app/products/charges/view-charge/view-charge.component.ts`
- `npm test -- --runInBand --runTestsByPath src/app/core/utils/charge-time-type.spec.ts src/app/products/charges/create-charge/create-charge.component.spec.ts src/app/products/charges/edit-charge/edit-charge.component.spec.ts src/app/products/charges/view-charge/view-charge.component.spec.ts src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.spec.ts --coverage=false`
