### PR TITLE
Allow periodic loan charges in create-loan form and preview

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.spec.ts
@@ -86,7 +86,7 @@ describe('LoansAccountChargesStepComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Every 1 year, starts on first repayment date');
   });
 
-  it('does not allow date editing for periodic loan charges', () => {
-    expect(component.canEditChargeDate(periodicCharge)).toBe(false);
+  it('allows date editing for periodic loan charges', () => {
+    expect(component.canEditChargeDate(periodicCharge)).toBe(true);
   });
 });

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -384,7 +384,7 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     return (
       isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
       isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
-      (isPeriodicLoanChargeTime(charge?.chargeTimeType) && !!charge?.dueDate)
+      isPeriodicLoanChargeTime(charge?.chargeTimeType)
     );
   }
 
@@ -400,7 +400,8 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     return (
       isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
       isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
-      isAnnualFeeChargeTime(charge?.chargeTimeType)
+      isAnnualFeeChargeTime(charge?.chargeTimeType) ||
+      isPeriodicLoanChargeTime(charge?.chargeTimeType)
     );
   }
 

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
@@ -131,7 +131,7 @@ export class LoansAccountPreviewStepComponent implements OnChanges {
     return (
       isSpecifiedDueDateChargeTime(charge?.chargeTimeType) ||
       isWeeklyFeeChargeTime(charge?.chargeTimeType) ||
-      (isPeriodicLoanChargeTime(charge?.chargeTimeType) && !!charge?.dueDate)
+      isPeriodicLoanChargeTime(charge?.chargeTimeType)
     );
   }
 

--- a/src/app/loans/loans.service.spec.ts
+++ b/src/app/loans/loans.service.spec.ts
@@ -32,7 +32,7 @@ describe('LoansService', () => {
     service = TestBed.inject(LoansService);
   });
 
-  it('filters periodic loan charges out of manual loan charge submissions', () => {
+  it('forwards all manual loan charges including periodic charges', () => {
     const periodicCharge = {
       chargeId: 21,
       amount: 10,
@@ -57,10 +57,13 @@ describe('LoansService', () => {
         disbursementCharge,
         periodicCharge
       ])
-    ).toEqual([disbursementCharge]);
+    ).toEqual([
+      disbursementCharge,
+      periodicCharge
+    ]);
   });
 
-  it('omits periodic loan charges when building the loan request payload', () => {
+  it('forwards periodic loan charges when building the loan request payload', () => {
     const payload = service.buildLoanRequestPayload(
       {
         charges: [
@@ -77,6 +80,7 @@ describe('LoansService', () => {
           {
             chargeId: 21,
             amount: 10,
+            dueDate: '2026-04-15',
             chargeTimeType: {
               id: 17,
               code: 'chargeTimeType.loanPeriodic',
@@ -105,6 +109,11 @@ describe('LoansService', () => {
         chargeId: 13,
         amount: 1.99,
         dueDate: 'formatted:2026-03-20'
+      },
+      {
+        chargeId: 21,
+        amount: 10,
+        dueDate: 'formatted:2026-04-15'
       }
     ]);
   });

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -718,12 +718,6 @@ export class LoansService {
           if (charge.dueDate) {
             mappedCharge.dueDate = this.dateUtils.formatDate(charge.dueDate, dateFormat);
           }
-          if (charge.feeInterval !== undefined) {
-            mappedCharge.feeInterval = charge.feeInterval;
-          }
-          if (charge.feeOnMonthDay !== undefined) {
-            mappedCharge.feeOnMonthDay = charge.feeOnMonthDay;
-          }
           return mappedCharge;
         })
         .filter(Boolean),
@@ -792,7 +786,7 @@ export class LoansService {
   }
 
   filterManualLoanCharges<T extends { chargeTimeType?: any }>(charges: T[] = []): T[] {
-    return (charges ?? []).filter((charge) => !!charge && !isPeriodicLoanChargeTime(charge.chargeTimeType));
+    return (charges ?? []).filter((charge) => !!charge);
   }
 
   saveLoanDisbursementDetailsData(disbursementData: DisbursementData[]): void {
@@ -800,6 +794,6 @@ export class LoansService {
   }
 
   getLoanDisbursementDetailsData(): DisbursementData[] {
-    return JSON.parse(localStorage.getItem('disbursementData'));
+    return JSON.parse(localStorage.getItem('disbursementData') ?? '[]');
   }
 }


### PR DESCRIPTION
## Summary

Removes the UI-side block that stripped `LOAN_PERIODIC` charges from loan submission/calculator payloads and extends the create-loan form to let users pick a due date on periodic charges. Pairs with [my-mnzl/fineract#22](https://github.com/my-mnzl/fineract/pull/22), which on the server side projects one UI entry into all yearly/monthly occurrences across the loan term.

## What changed

- **`loans.service.ts`**
  - `filterManualLoanCharges` no longer drops periodic charges — all charges flow through to the request payload.
  - `buildLoanRequestPayload` stops forwarding per-entry `feeInterval` / `feeOnMonthDay` (rejected by Fineract's bulk-charge validator; those values come from the charge definition).
  - `getLoanDisbursementDetailsData` is null-safe (`?? '[]'`).
- **`loans-account-charges-step.component.ts`** — `showsDueDate` and `canEditChargeDate` now return `true` for periodic charges, so the create-loan form shows the due-date picker and allows editing (previously the field was read-only / hidden).
- **`loans-account-preview-step.component.ts`** — preview step mirrors the same show-due-date behaviour.
- **Specs updated** — `loans.service.spec.ts` now asserts periodic charges are forwarded; `loans-account-charges-step.component.spec.ts` flipped from "does not allow date editing" to "allows date editing."

## Tests

`npx jest --testPathPattern="loans.service.spec|loans-account-charges-step.component.spec|loans-account-preview-step.component.spec|charge-time-type.spec"` — **11/11 pass**.