### PR TITLE
Redesign holidays + working-days with calendar view and bulk actions

### DIFF
--- a/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.html
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.html
@@ -1,0 +1,135 @@
+<div class="ai-dialog">
+  <header class="ai-head">
+    <h2 class="ai-title" mat-dialog-title>{{ 'labels.heading.Auto-fill Holidays' | translate }}</h2>
+    <p class="ai-sub">
+      {{ 'labels.text.Egypt official holidays via Google Calendar' | translate }}
+    </p>
+  </header>
+
+  <mat-dialog-content class="ai-content">
+    <form [formGroup]="configForm" class="ai-config">
+      <div class="ai-row">
+        <mat-form-field appearance="outline" class="ai-year">
+          <mat-label>{{ 'labels.inputs.Year' | translate }}</mat-label>
+          <mat-select formControlName="year" (selectionChange)="fetch()">
+            @for (year of yearOptions; track year) {
+              <mat-option [value]="year">{{ year }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="ai-resched">
+          <mat-label>{{ 'labels.inputs.Repayments Scheduling Type' | translate }}</mat-label>
+          <mat-select formControlName="reschedulingType">
+            @for (opt of reschedulingOptions; track opt.id) {
+              <mat-option [value]="opt.id">{{ opt.value }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <div class="ai-offices">
+        <div class="ai-label">{{ 'labels.inputs.Apply to offices' | translate }}</div>
+        <div class="ai-offices-list">
+          @for (office of data.offices; track office.id) {
+            <button
+              type="button"
+              class="ai-chip"
+              [class.is-on]="isOfficeSelected(office.id)"
+              (click)="toggleOffice(office.id)"
+            >
+              {{ office.name }}
+            </button>
+          }
+        </div>
+      </div>
+    </form>
+
+    <hr class="ai-rule" />
+
+    @if (loading) {
+      <div class="ai-state">
+        <p>{{ 'labels.text.Loading holidays' | translate }}</p>
+      </div>
+    } @else if (errorMessage && !importResult) {
+      <div class="ai-state ai-state-error">
+        <p>{{ errorMessage }}</p>
+        <button mat-stroked-button (click)="fetch()">{{ 'labels.buttons.Retry' | translate }}</button>
+      </div>
+    } @else if (importResult) {
+      <div class="ai-state ai-state-success">
+        <p class="ai-success-line">
+          <span class="ai-success-num">{{ importResult.success }}</span>
+          {{ 'labels.text.holidays imported' | translate }}
+        </p>
+        @if (importResult.failed > 0) {
+          <p class="ai-failed">{{ importResult.failed }} {{ 'labels.text.failed to import' | translate }}</p>
+        }
+      </div>
+    } @else if (importing) {
+      <div class="ai-state">
+        <p>{{ 'labels.text.Importing' | translate }} {{ importProgress.done }} / {{ importProgress.total }}</p>
+        <mat-progress-bar mode="determinate" [value]="importPercent" class="ai-progress"></mat-progress-bar>
+      </div>
+    } @else {
+      <div class="ai-preview-head">
+        <label class="ai-select-all">
+          <mat-checkbox
+            [checked]="allSelected"
+            [indeterminate]="someSelected"
+            (change)="toggleAll($event.checked)"
+          ></mat-checkbox>
+          <span>{{ selectedCount }} / {{ preview.length }} {{ 'labels.text.selected' | translate }}</span>
+        </label>
+      </div>
+
+      <ul class="ai-list">
+        @for (row of preview; track row.uid || row.summary) {
+          <li class="ai-item" [class.is-on]="row.selected" (click)="toggleRow(row)">
+            <mat-checkbox
+              [checked]="row.selected"
+              (click)="$event.stopPropagation()"
+              (change)="toggleRow(row)"
+            ></mat-checkbox>
+            <div class="ai-item-info">
+              <div class="ai-item-name">{{ row.summary }}</div>
+              <div class="ai-item-dates">
+                <span>{{ row.start | date: 'mediumDate' }}</span>
+                @if (row.end.getTime() !== row.start.getTime()) {
+                  <span class="ai-arrow">→</span>
+                  <span>{{ row.end | date: 'mediumDate' }}</span>
+                }
+              </div>
+            </div>
+          </li>
+        }
+      </ul>
+    }
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="ai-actions">
+    @if (importResult) {
+      <button mat-flat-button color="primary" (click)="finish()">
+        {{ 'labels.buttons.Done' | translate }}
+      </button>
+    } @else {
+      <button mat-button (click)="cancel()" [disabled]="importing">
+        {{ 'labels.buttons.Cancel' | translate }}
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        (click)="confirm()"
+        [disabled]="
+          loading ||
+          importing ||
+          selectedCount === 0 ||
+          configForm.invalid ||
+          (configForm.value.offices?.length ?? 0) === 0
+        "
+      >
+        {{ 'labels.buttons.Import' | translate }} ({{ selectedCount }})
+      </button>
+    }
+  </mat-dialog-actions>
+</div>

--- a/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.scss
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.scss
@@ -1,0 +1,249 @@
+:host {
+  display: block;
+
+  --ai-border: rgb(15 23 42 / 8%);
+  --ai-text: rgb(15 23 42 / 92%);
+  --ai-text-mid: rgb(15 23 42 / 65%);
+  --ai-text-dim: rgb(15 23 42 / 45%);
+  --ai-accent: #1074b9;
+}
+
+.ai-dialog {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ---------- Header ---------- */
+.ai-head {
+  padding: 4px 4px 14px;
+  border-bottom: 1px solid var(--ai-border);
+}
+
+.ai-title {
+  margin: 0 !important;
+  font-size: 18px !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em;
+  color: var(--ai-text) !important;
+}
+
+.ai-sub {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--ai-text-mid);
+}
+
+/* ---------- Content ---------- */
+.ai-content {
+  padding: 18px 4px !important;
+  max-height: 65vh;
+}
+
+.ai-config {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ai-row {
+  display: flex;
+  gap: 12px;
+}
+
+.ai-year {
+  flex: 0 1 160px;
+}
+
+.ai-resched {
+  flex: 1 1 auto;
+}
+
+.ai-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ai-text-dim);
+  margin-bottom: 8px;
+}
+
+/* ---------- Office chips ---------- */
+.ai-offices-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ai-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--ai-border);
+  background: transparent;
+  color: var(--ai-text-mid);
+  font-size: 12.5px;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.ai-chip:hover {
+  border-color: rgb(15 23 42 / 24%);
+  color: var(--ai-text);
+}
+
+.ai-chip.is-on {
+  background: var(--ai-accent);
+  border-color: var(--ai-accent);
+  color: #fff;
+}
+
+.ai-rule {
+  border: none;
+  border-top: 1px solid var(--ai-border);
+  margin: 18px 0 16px;
+}
+
+/* ---------- States ---------- */
+.ai-state {
+  padding: 28px 8px;
+  text-align: center;
+  color: var(--ai-text-mid);
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: center;
+}
+
+.ai-state p {
+  margin: 0;
+}
+
+.ai-state-error {
+  color: #b91c1c;
+}
+
+.ai-state-success {
+  color: var(--ai-text);
+}
+
+.ai-success-num {
+  color: #2e7d32;
+  font-weight: 600;
+  font-size: 22px;
+  margin-right: 4px;
+}
+
+.ai-success-line {
+  font-size: 16px;
+}
+
+.ai-failed {
+  color: #b45309;
+  font-size: 13px;
+}
+
+.ai-progress {
+  width: 220px;
+}
+
+/* ---------- Preview list ---------- */
+.ai-preview-head {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.ai-select-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--ai-text-mid);
+  cursor: pointer;
+}
+
+.ai-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+  overflow-y: auto;
+  border-top: 1px solid var(--ai-border);
+}
+
+.ai-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--ai-border);
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.ai-item:hover {
+  background: rgb(16 116 185 / 4%);
+}
+
+.ai-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ai-item-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ai-text-mid);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-item.is-on .ai-item-name {
+  color: var(--ai-text);
+}
+
+.ai-item-dates {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ai-text-dim);
+  font-size: 12px;
+  font-feature-settings: 'tnum';
+}
+
+.ai-arrow {
+  opacity: 0.5;
+}
+
+/* ---------- Actions ---------- */
+.ai-actions {
+  padding: 12px 4px 4px !important;
+  gap: 8px;
+  justify-content: flex-end;
+  border-top: 1px solid var(--ai-border);
+}
+
+/* ---------- Dark mode ---------- */
+:host-context(.dark-mode),
+:host-context([data-theme='dark']) {
+  --ai-border: rgb(255 255 255 / 8%);
+  --ai-text: rgb(255 255 255 / 92%);
+  --ai-text-mid: rgb(255 255 255 / 65%);
+  --ai-text-dim: rgb(255 255 255 / 45%);
+}
+
+:host-context(.dark-mode) .ai-item:hover,
+:host-context([data-theme='dark']) .ai-item:hover {
+  background: rgb(91 162 236 / 8%);
+}

--- a/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.ts
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.ts
@@ -1,0 +1,282 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { TranslateService } from '@ngx-translate/core';
+import { from, of } from 'rxjs';
+import { catchError, finalize, map, mergeMap, tap } from 'rxjs/operators';
+
+import { OrganizationService } from '../../organization.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { parseICalEvents, ParsedICalEvent } from './ical-parser';
+
+interface DialogData {
+  offices: Array<{ id: number; name: string }>;
+  defaultOfficeId: number | null;
+}
+
+interface PreviewRow extends ParsedICalEvent {
+  selected: boolean;
+}
+
+/** Shape of the payload we POST to /holidays. Matches what create-holiday sends. */
+interface HolidayCreatePayload {
+  name: string;
+  fromDate: string;
+  toDate: string;
+  reschedulingType: number;
+  description: string;
+  offices: Array<{ officeId: number }>;
+  dateFormat: string;
+  locale: string;
+  repaymentsRescheduledTo?: string;
+}
+
+const HOLIDAY_CALENDAR_ID = 'en.eg.official#holiday@group.v.calendar.google.com';
+const IMPORT_CONCURRENCY = 3;
+
+/**
+ * Public iCal feed for the calendar. Google's iCal endpoint does not return CORS
+ * headers, so the request is routed through corsproxy.io.
+ */
+function buildIcsUrl(): string {
+  const encodedId = encodeURIComponent(HOLIDAY_CALENDAR_ID);
+  const target = `https://calendar.google.com/calendar/ical/${encodedId}/public/basic.ics`;
+  return `https://corsproxy.io/?${encodeURIComponent(target)}`;
+}
+
+@Component({
+  selector: 'mifosx-holiday-auto-import-dialog',
+  standalone: true,
+  templateUrl: './holiday-auto-import-dialog.component.html',
+  styleUrls: ['./holiday-auto-import-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatDialogActions,
+    MatDialogContent,
+    MatDialogTitle,
+    MatButton,
+    MatCheckbox,
+    MatProgressBar
+  ]
+})
+export class HolidayAutoImportDialogComponent implements OnInit {
+  private fb = inject(UntypedFormBuilder);
+  private http = inject(HttpClient);
+  private organizationService = inject(OrganizationService);
+  private settings = inject(SettingsService);
+  private dateUtils = inject(Dates);
+  private translate = inject(TranslateService);
+  private cdr = inject(ChangeDetectorRef);
+  private dialogRef = inject(MatDialogRef<HolidayAutoImportDialogComponent>);
+
+  configForm: UntypedFormGroup;
+  yearOptions: number[] = [];
+  reschedulingOptions = [
+    { id: 1, value: 'Reschedule to next repayment date' },
+    { id: 2, value: 'Reschedule to a specific date' }
+  ];
+
+  loading = false;
+  importing = false;
+  errorMessage = '';
+  preview: PreviewRow[] = [];
+  importProgress = { done: 0, total: 0 };
+  importResult: { success: number; failed: number } | null = null;
+
+  data = inject<DialogData>(MAT_DIALOG_DATA);
+
+  constructor() {
+    const currentYear = new Date().getFullYear();
+    this.yearOptions = [
+      currentYear - 1,
+      currentYear,
+      currentYear + 1,
+      currentYear + 2
+    ];
+
+    const defaultOffices: number[] = this.data.defaultOfficeId != null ? [this.data.defaultOfficeId] : [];
+    this.configForm = this.fb.group({
+      year: [
+        currentYear,
+        Validators.required
+      ],
+      reschedulingType: [
+        1,
+        Validators.required
+      ],
+      offices: [
+        defaultOffices,
+        Validators.required
+      ]
+    });
+  }
+
+  ngOnInit(): void {
+    this.fetch();
+  }
+
+  fetch(): void {
+    this.loading = true;
+    this.errorMessage = '';
+    this.preview = [];
+    this.importResult = null;
+
+    this.http.get(buildIcsUrl(), { responseType: 'text' }).subscribe({
+      next: (ics) => {
+        const events = parseICalEvents(ics);
+        const year = this.configForm.value.year;
+        this.preview = events
+          .filter((e) => e.start.getFullYear() === year)
+          .sort((a, b) => a.start.getTime() - b.start.getTime())
+          .map((e) => ({ ...e, selected: true }));
+        this.loading = false;
+        if (this.preview.length === 0) {
+          this.errorMessage = `No holidays found for ${year}.`;
+        }
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loading = false;
+        this.errorMessage = this.translate.instant(
+          'labels.text.Could not load holidays from Google Calendar'
+        ) as string;
+        if (!this.errorMessage || this.errorMessage.startsWith('labels.')) {
+          this.errorMessage =
+            'Could not load holidays from Google Calendar. Check your network connection and try again.';
+        }
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  toggleAll(checked: boolean): void {
+    this.preview = this.preview.map((row) => ({ ...row, selected: checked }));
+  }
+
+  toggleRow(row: PreviewRow): void {
+    row.selected = !row.selected;
+    this.preview = [...this.preview];
+  }
+
+  get allSelected(): boolean {
+    return this.preview.length > 0 && this.preview.every((r) => r.selected);
+  }
+
+  get someSelected(): boolean {
+    return this.preview.some((r) => r.selected) && !this.allSelected;
+  }
+
+  get selectedCount(): number {
+    return this.preview.filter((r) => r.selected).length;
+  }
+
+  get importPercent(): number {
+    if (!this.importProgress.total) return 0;
+    return Math.round((this.importProgress.done / this.importProgress.total) * 100);
+  }
+
+  toggleOffice(officeId: number): void {
+    const current: number[] = this.configForm.value.offices ?? [];
+    const next = current.includes(officeId) ? current.filter((id) => id !== officeId) : [
+          ...current,
+          officeId
+        ];
+    this.configForm.patchValue({ offices: next });
+  }
+
+  isOfficeSelected(officeId: number): boolean {
+    return (this.configForm.value.offices ?? []).includes(officeId);
+  }
+
+  cancel(): void {
+    this.dialogRef.close({ imported: false });
+  }
+
+  /**
+   * Imports the selected holidays with limited concurrency so we don't stampede the
+   * backend, and surfaces a per-item progress bar instead of an opaque spinner.
+   */
+  confirm(): void {
+    const selected = this.preview.filter((r) => r.selected);
+    const officeIds: number[] = this.configForm.value.offices ?? [];
+    if (selected.length === 0 || officeIds.length === 0 || this.configForm.invalid) {
+      return;
+    }
+    this.importing = true;
+    this.importProgress = { done: 0, total: selected.length };
+
+    // Send ISO dates with a fixed dateFormat / locale. The display-side DateFormatPipe
+    // mutates moment's global locale on every render, so a localized format like
+    // 'DD MMMM YYYY' would produce e.g. Arabic month names while the request claims
+    // locale='en' — and the backend would reject the payload.
+    const dateFormat = 'yyyy-MM-dd';
+    const locale = 'en';
+    const momentFormat = 'YYYY-MM-DD';
+    const reschedulingType = this.configForm.value.reschedulingType;
+    const offices = officeIds.map((id) => ({ officeId: id }));
+    const description = this.translate.instant('labels.text.Imported from Google Calendar') as string;
+
+    let success = 0;
+    let failed = 0;
+    from(selected)
+      .pipe(
+        mergeMap((row) => {
+          const payload: HolidayCreatePayload = {
+            name: row.summary,
+            fromDate: this.dateUtils.formatDateAsString(row.start, momentFormat),
+            toDate: this.dateUtils.formatDateAsString(row.end, momentFormat),
+            reschedulingType,
+            description: description.startsWith('labels.') ? 'Imported from Google Calendar' : description,
+            offices,
+            dateFormat,
+            locale
+          };
+          if (reschedulingType === 2) {
+            const next = new Date(row.end);
+            next.setDate(next.getDate() + 1);
+            payload.repaymentsRescheduledTo = this.dateUtils.formatDateAsString(next, momentFormat);
+          }
+          return this.organizationService.createHoliday(payload).pipe(
+            map(() => true),
+            catchError(() => of(false))
+          );
+        }, IMPORT_CONCURRENCY),
+        tap((ok) => {
+          if (ok) success++;
+          else failed++;
+          this.importProgress = { done: success + failed, total: selected.length };
+          this.cdr.markForCheck();
+        }),
+        finalize(() => {
+          this.importing = false;
+          this.importResult = { success, failed };
+          this.cdr.markForCheck();
+          if (failed === 0) {
+            setTimeout(() => this.dialogRef.close({ imported: true }), 700);
+          }
+        })
+      )
+      .subscribe();
+  }
+
+  finish(): void {
+    this.dialogRef.close({ imported: !!this.importResult && this.importResult.success > 0 });
+  }
+}

--- a/src/app/organization/holidays/holiday-auto-import-dialog/ical-parser.spec.ts
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/ical-parser.spec.ts
@@ -1,0 +1,151 @@
+import { parseICalEvents } from './ical-parser';
+
+const MIN_VEVENT = (props: string[]) =>
+  `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\n${props.join('\n')}\nEND:VEVENT\nEND:VCALENDAR`;
+
+describe('parseICalEvents', () => {
+  it('returns an empty array for empty or whitespace input', () => {
+    expect(parseICalEvents('')).toEqual([]);
+    expect(parseICalEvents('   \n\n')).toEqual([]);
+  });
+
+  it('parses a single all-day event with VALUE=DATE form', () => {
+    const ics = MIN_VEVENT([
+      'UID:1@example',
+      'SUMMARY:Coptic Christmas',
+      'DTSTART;VALUE=DATE:20260107',
+      'DTEND;VALUE=DATE:20260108'
+    ]);
+    const events = parseICalEvents(ics);
+    expect(events).toHaveLength(1);
+    expect(events[0].summary).toBe('Coptic Christmas');
+    expect(events[0].start.getFullYear()).toBe(2026);
+    expect(events[0].start.getMonth()).toBe(0);
+    expect(events[0].start.getDate()).toBe(7);
+    // DTEND for VALUE=DATE is exclusive in iCal — the parser must subtract a
+    // day so that a single-day holiday's `end` is the same as `start`.
+    expect(events[0].end.getDate()).toBe(7);
+  });
+
+  it('keeps DTEND as-is when the property uses date-time form', () => {
+    const ics = MIN_VEVENT([
+      'UID:dt@example',
+      'SUMMARY:Meeting',
+      'DTSTART:20260107T090000Z',
+      'DTEND:20260107T100000Z'
+    ]);
+    const [
+      e
+    ] = parseICalEvents(ics);
+    // Date-time DTEND should NOT have a day subtracted.
+    expect(e.start.getUTCDate()).toBe(7);
+    expect(e.end.getUTCDate()).toBe(7);
+    expect(e.end.getUTCHours()).toBe(10);
+  });
+
+  it('handles RFC 5545 line folding (CRLF + space continuation)', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:fold@example',
+      'SUMMARY:This is a very long\r\n  summary that was folded',
+      'DTSTART;VALUE=DATE:20260101',
+      'DTEND;VALUE=DATE:20260102',
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ].join('\r\n');
+    const [
+      e
+    ] = parseICalEvents(ics);
+    expect(e.summary).toBe('This is a very long summary that was folded');
+  });
+
+  it('unescapes commas, semicolons, backslashes, and \\n in SUMMARY', () => {
+    const ics = MIN_VEVENT([
+      'UID:esc@example',
+      'SUMMARY:Day off\\, family event\\; relax\\\\ a bit\\nback Monday',
+      'DTSTART;VALUE=DATE:20260301',
+      'DTEND;VALUE=DATE:20260302'
+    ]);
+    const [
+      e
+    ] = parseICalEvents(ics);
+    expect(e.summary).toBe('Day off, family event; relax\\ a bit back Monday');
+  });
+
+  it('parses multi-day spans correctly (DTEND inclusive after subtraction)', () => {
+    const ics = MIN_VEVENT([
+      'UID:multi@example',
+      'SUMMARY:Eid al-Fitr',
+      'DTSTART;VALUE=DATE:20260320',
+      'DTEND;VALUE=DATE:20260323'
+    ]);
+    const [
+      e
+    ] = parseICalEvents(ics);
+    expect(e.start.getDate()).toBe(20);
+    expect(e.end.getDate()).toBe(22);
+  });
+
+  it('skips VEVENTs missing required fields', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:incomplete@example',
+      'DTSTART;VALUE=DATE:20260101',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'UID:ok@example',
+      'SUMMARY:Valid Event',
+      'DTSTART;VALUE=DATE:20260201',
+      'DTEND;VALUE=DATE:20260202',
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ].join('\n');
+    const events = parseICalEvents(ics);
+    expect(events).toHaveLength(1);
+    expect(events[0].summary).toBe('Valid Event');
+  });
+
+  it('parses multiple events and preserves their UIDs', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:a@example',
+      'SUMMARY:First',
+      'DTSTART;VALUE=DATE:20260101',
+      'DTEND;VALUE=DATE:20260102',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'UID:b@example',
+      'SUMMARY:Second',
+      'DTSTART;VALUE=DATE:20260214',
+      'DTEND;VALUE=DATE:20260215',
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ].join('\n');
+    const events = parseICalEvents(ics);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.uid)).toEqual([
+      'a@example',
+      'b@example'
+    ]);
+  });
+
+  it('ignores properties outside a VEVENT block', () => {
+    const ics = [
+      'BEGIN:VCALENDAR',
+      'SUMMARY:Calendar Title — should be ignored',
+      'BEGIN:VEVENT',
+      'UID:c@example',
+      'SUMMARY:Real',
+      'DTSTART;VALUE=DATE:20260101',
+      'DTEND;VALUE=DATE:20260102',
+      'END:VEVENT',
+      'END:VCALENDAR'
+    ].join('\n');
+    const events = parseICalEvents(ics);
+    expect(events).toHaveLength(1);
+    expect(events[0].summary).toBe('Real');
+  });
+});

--- a/src/app/organization/holidays/holiday-auto-import-dialog/ical-parser.ts
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/ical-parser.ts
@@ -1,0 +1,86 @@
+/**
+ * Tiny iCal/ICS VEVENT parser.
+ *
+ * The Google Calendar holiday feeds we consume only need DTSTART, DTEND, and SUMMARY,
+ * so this avoids pulling in a full iCal dependency. It handles line folding (RFC 5545)
+ * and the two date forms we encounter:
+ *   - DATE:           DTSTART;VALUE=DATE:20260107
+ *   - DATE-TIME UTC:  DTSTART:20260107T000000Z
+ */
+
+export interface ParsedICalEvent {
+  summary: string;
+  start: Date;
+  end: Date;
+  uid?: string;
+}
+
+export function parseICalEvents(ics: string): ParsedICalEvent[] {
+  if (!ics) return [];
+
+  // RFC 5545 line unfolding: a CRLF followed by a space or tab is a continuation.
+  const unfolded = ics.replace(/\r?\n[ \t]/g, '');
+  const lines = unfolded.split(/\r?\n/);
+
+  const events: ParsedICalEvent[] = [];
+  let current: Partial<ParsedICalEvent> | null = null;
+
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      current = {};
+      continue;
+    }
+    if (line === 'END:VEVENT') {
+      if (current && current.summary && current.start && current.end) {
+        events.push(current as ParsedICalEvent);
+      }
+      current = null;
+      continue;
+    }
+    if (!current) continue;
+
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const head = line.slice(0, colonIdx);
+    const value = line.slice(colonIdx + 1);
+    const [name] = head.split(';');
+
+    if (name === 'SUMMARY') {
+      current.summary = unescapeICalText(value);
+    } else if (name === 'UID') {
+      current.uid = value;
+    } else if (name === 'DTSTART') {
+      current.start = parseICalDate(value);
+    } else if (name === 'DTEND') {
+      // iCal DTEND is exclusive for all-day events. Subtract one day so it represents
+      // the inclusive last day, matching how Mifos models a holiday's "to" date.
+      const end = parseICalDate(value);
+      if (head.includes('VALUE=DATE')) {
+        end.setDate(end.getDate() - 1);
+      }
+      current.end = end;
+    }
+  }
+
+  return events;
+}
+
+function parseICalDate(value: string): Date {
+  // YYYYMMDD
+  if (/^\d{8}$/.test(value)) {
+    const y = +value.slice(0, 4);
+    const m = +value.slice(4, 6) - 1;
+    const d = +value.slice(6, 8);
+    return new Date(y, m, d);
+  }
+  // YYYYMMDDTHHmmssZ (UTC)
+  const m = value.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z?$/);
+  if (m) {
+    return new Date(Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6]));
+  }
+  return new Date(value);
+}
+
+function unescapeICalText(value: string): string {
+  return value.replace(/\\n/g, ' ').replace(/\\,/g, ',').replace(/\\;/g, ';').replace(/\\\\/g, '\\');
+}

--- a/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.html
+++ b/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.html
@@ -1,0 +1,76 @@
+<div class="cal">
+  <div class="cal-toolbar">
+    <div class="cal-nav">
+      <button
+        type="button"
+        class="cal-nav-btn"
+        (click)="prevMonth()"
+        [attr.aria-label]="'labels.buttons.Previous month' | translate"
+      >
+        <fa-icon icon="chevron-left"></fa-icon>
+      </button>
+      <h2 class="cal-month">{{ monthLabel }}</h2>
+      <button
+        type="button"
+        class="cal-nav-btn"
+        (click)="nextMonth()"
+        [attr.aria-label]="'labels.buttons.Next month' | translate"
+      >
+        <fa-icon icon="chevron-right"></fa-icon>
+      </button>
+    </div>
+    <button type="button" class="cal-today" (click)="goToday()">
+      {{ 'labels.buttons.Today' | translate }}
+    </button>
+  </div>
+
+  <div class="cal-weekdays">
+    @for (label of weekDayLabels; track label) {
+      <div class="cal-weekday">{{ label }}</div>
+    }
+  </div>
+
+  <div class="cal-grid">
+    @for (week of weeks; track trackWeek($index, week)) {
+      <div class="cal-week" [style.--lanes]="week.laneCount">
+        @for (day of week.days; track trackDay($index, day); let dayIdx = $index) {
+          <button
+            type="button"
+            class="cal-day"
+            [class.is-out]="!day.inMonth"
+            [class.is-today]="day.isToday"
+            [class.is-weekend]="day.isWeekend"
+            [style.grid-column]="dayIdx + 1"
+            (click)="dayClick.emit(day.date)"
+          >
+            <span class="cal-day-num">{{ day.date.getDate() }}</span>
+          </button>
+        }
+
+        @for (bar of week.bars; track trackBar($index, bar)) {
+          @if (bar.lane < maxVisibleLanes) {
+            <button
+              type="button"
+              class="cal-bar"
+              [class.is-start]="bar.startsHere"
+              [class.is-end]="bar.endsHere"
+              [style.grid-column]="bar.startCol + 1 + ' / ' + (bar.endCol + 2)"
+              [style.grid-row]="bar.lane + 2"
+              [style.--hue]="bar.hue"
+              [title]="bar.holiday.name"
+              (click)="openHoliday(bar.holiday, $event)"
+            >
+              <span class="cal-bar-text">{{ bar.holiday.name }}</span>
+            </button>
+          }
+        }
+
+        @if (week.laneCount > maxVisibleLanes) {
+          <div class="cal-overflow" [style.grid-row]="maxVisibleLanes + 2">
+            +{{ week.laneCount - maxVisibleLanes }} more
+          </div>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.scss
+++ b/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.scss
@@ -1,0 +1,271 @@
+:host {
+  display: block;
+
+  --cal-border: rgb(15 23 42 / 8%);
+  --cal-border-strong: rgb(15 23 42 / 14%);
+  --cal-text-dim: rgb(15 23 42 / 38%);
+  --cal-text-mid: rgb(15 23 42 / 60%);
+  --cal-text: rgb(15 23 42 / 90%);
+  --cal-bg-out: rgb(15 23 42 / 2%);
+  --cal-today: #1074b9;
+}
+
+.cal {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ---------- Toolbar ---------- */
+.cal-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.cal-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cal-month {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--cal-text);
+  font-feature-settings: 'tnum';
+  min-width: 180px;
+  text-align: center;
+}
+
+.cal-nav-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid var(--cal-border);
+  color: var(--cal-text-mid);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 13px;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.cal-nav-btn:hover {
+  border-color: var(--cal-border-strong);
+  color: var(--cal-text);
+}
+
+.cal-today {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  border: 1px solid var(--cal-border);
+  background: transparent;
+  color: var(--cal-text-mid);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.cal-today:hover {
+  border-color: var(--cal-border-strong);
+  color: var(--cal-text);
+}
+
+/* ---------- Weekday header ---------- */
+.cal-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 14.2857%));
+  border-bottom: 1px solid var(--cal-border);
+}
+
+.cal-weekday {
+  padding: 8px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--cal-text-dim);
+}
+
+/* ---------- Grid ---------- */
+.cal-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.cal-week {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 14.2857%));
+  grid-auto-rows: minmax(20px, auto);
+  position: relative;
+  border-bottom: 1px solid var(--cal-border);
+  min-height: calc(36px + var(--lanes, 0) * 22px + 12px);
+}
+
+.cal-week:last-child {
+  border-bottom: none;
+}
+
+/* ---------- Day cell ---------- */
+.cal-day {
+  grid-row: 1;
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--cal-border);
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 6px 8px 0;
+  min-height: 88px;
+  text-align: left;
+  transition: background 0.12s ease;
+}
+
+.cal-day:last-child {
+  border-right: none;
+}
+
+.cal-day:hover {
+  background: rgb(16 116 185 / 4%);
+}
+
+.cal-day-num {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--cal-text-mid);
+  font-feature-settings: 'tnum';
+  width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+}
+
+.cal-day.is-out {
+  background: var(--cal-bg-out);
+}
+
+.cal-day.is-out .cal-day-num {
+  color: var(--cal-text-dim);
+}
+
+.cal-day.is-today .cal-day-num {
+  background: var(--cal-today);
+  color: #fff;
+  border-radius: 50%;
+  font-weight: 600;
+}
+
+/* ---------- Event bars ---------- */
+.cal-bar {
+  position: relative;
+  margin: 1px 2px;
+  height: 20px;
+  border-radius: 4px;
+  border: 0;
+  background: oklch(94% 0.05 var(--hue, 220));
+  color: oklch(38% 0.18 var(--hue, 220));
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: left;
+  z-index: 1;
+  transition: filter 0.12s ease;
+}
+
+.cal-bar:hover {
+  filter: brightness(0.96);
+}
+
+.cal-bar:not(.is-start) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: 0;
+}
+
+.cal-bar:not(.is-end) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-right: 0;
+}
+
+.cal-bar-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cal-bar:not(.is-start) .cal-bar-text {
+  visibility: hidden;
+}
+
+.cal-overflow {
+  grid-column: 1 / -1;
+  padding: 2px 10px 4px;
+  font-size: 11px;
+  color: var(--cal-text-dim);
+  font-weight: 500;
+  pointer-events: none;
+}
+
+/* ---------- Dark mode ---------- */
+:host-context(.dark-mode),
+:host-context([data-theme='dark']) {
+  --cal-border: rgb(255 255 255 / 8%);
+  --cal-border-strong: rgb(255 255 255 / 16%);
+  --cal-text-dim: rgb(255 255 255 / 38%);
+  --cal-text-mid: rgb(255 255 255 / 65%);
+  --cal-text: rgb(255 255 255 / 92%);
+  --cal-bg-out: rgb(255 255 255 / 2%);
+}
+
+:host-context(.dark-mode) .cal-bar,
+:host-context([data-theme='dark']) .cal-bar {
+  background: oklch(28% 0.06 var(--hue, 220));
+  color: oklch(82% 0.1 var(--hue, 220));
+}
+
+:host-context(.dark-mode) .cal-day:hover,
+:host-context([data-theme='dark']) .cal-day:hover {
+  background: rgb(91 162 236 / 8%);
+}
+
+/* ---------- Responsive ---------- */
+@media (width <= 720px) {
+  .cal-day {
+    min-height: 64px;
+    padding: 4px 4px 0;
+  }
+
+  .cal-bar {
+    font-size: 10.5px;
+    height: 18px;
+    padding: 0 6px;
+  }
+
+  .cal-month {
+    font-size: 16px;
+    min-width: 140px;
+  }
+}

--- a/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.ts
+++ b/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.ts
@@ -1,0 +1,230 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  inject
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { Holiday, allocateLanes, hashHue, hashString, sameDay, startOfDay, toDate } from '../holiday-utils';
+
+interface DayCell {
+  date: Date;
+  inMonth: boolean;
+  isToday: boolean;
+  isWeekend: boolean;
+}
+
+interface EventBar {
+  holiday: Holiday;
+  startCol: number;
+  endCol: number;
+  lane: number;
+  startsHere: boolean;
+  endsHere: boolean;
+  hue: number;
+}
+
+interface WeekRow {
+  days: DayCell[];
+  bars: EventBar[];
+  laneCount: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+const MAX_VISIBLE_LANES = 3;
+
+/** Day-of-week offset, 0 = Sunday … 6 = Saturday. */
+type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+@Component({
+  selector: 'mifosx-holiday-calendar',
+  standalone: true,
+  templateUrl: './holiday-calendar.component.html',
+  styleUrls: ['./holiday-calendar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    CommonModule,
+    FaIconComponent,
+    RouterLink
+  ]
+})
+export class HolidayCalendarComponent implements OnChanges {
+  private router = inject(Router);
+
+  @Input() holidays: Holiday[] = [];
+  @Input() month: Date = new Date();
+  @Input() weekStartsOn: DayOfWeek = 0;
+
+  @Output() monthChange = new EventEmitter<Date>();
+  @Output() dayClick = new EventEmitter<Date>();
+
+  weekDayLabels: string[] = [];
+  weeks: WeekRow[] = [];
+  monthLabel = '';
+  readonly maxVisibleLanes = MAX_VISIBLE_LANES;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['weekStartsOn'] || !this.weekDayLabels.length) {
+      this.weekDayLabels = this.computeWeekDayLabels();
+    }
+    if (changes['month'] || changes['holidays'] || changes['weekStartsOn']) {
+      this.rebuild();
+    }
+  }
+
+  prevMonth(): void {
+    const d = new Date(this.month.getFullYear(), this.month.getMonth() - 1, 1);
+    this.monthChange.emit(d);
+  }
+
+  nextMonth(): void {
+    const d = new Date(this.month.getFullYear(), this.month.getMonth() + 1, 1);
+    this.monthChange.emit(d);
+  }
+
+  goToday(): void {
+    const today = new Date();
+    this.monthChange.emit(new Date(today.getFullYear(), today.getMonth(), 1));
+  }
+
+  trackWeek(_: number, w: WeekRow): number {
+    return w.days[0].date.getTime();
+  }
+
+  trackDay(_: number, d: DayCell): number {
+    return d.date.getTime();
+  }
+
+  trackBar(_: number, b: EventBar): number {
+    return b.holiday.id * 1000 + b.lane;
+  }
+
+  openHoliday(h: Holiday, ev: Event): void {
+    ev.stopPropagation();
+    this.router.navigate([
+      '/organization/holidays',
+      h.id
+    ]);
+  }
+
+  /**
+   * Builds the visible weeks for the current `month` plus event bars per week.
+   * Multi-day holidays that span week boundaries are split into one bar per week,
+   * with rounded corners only at the true start/end of the holiday.
+   */
+  private rebuild(): void {
+    if (!this.month) return;
+    const year = this.month.getFullYear();
+    const monthIdx = this.month.getMonth();
+    this.monthLabel = this.month.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+
+    const today = startOfDay(new Date());
+    const firstOfMonth = new Date(year, monthIdx, 1);
+    const offset = (firstOfMonth.getDay() - this.weekStartsOn + 7) % 7;
+    const gridStart = new Date(year, monthIdx, 1 - offset);
+
+    // Always render 6 weeks so the layout doesn't jump between months.
+    const weeks: WeekRow[] = [];
+    for (let w = 0; w < 6; w++) {
+      const days: DayCell[] = [];
+      for (let d = 0; d < 7; d++) {
+        const date = new Date(gridStart.getFullYear(), gridStart.getMonth(), gridStart.getDate() + w * 7 + d);
+        days.push({
+          date,
+          inMonth: date.getMonth() === monthIdx,
+          isToday: sameDay(date, today),
+          isWeekend: date.getDay() === 0 || date.getDay() === 6
+        });
+      }
+      weeks.push({ days, bars: [], laneCount: 0 });
+    }
+
+    interface Seg {
+      holiday: Holiday;
+      weekIdx: number;
+      startCol: number;
+      endCol: number;
+      startsHere: boolean;
+      endsHere: boolean;
+      length: number;
+      absoluteStart: number;
+      hue: number;
+    }
+    const segs: Seg[] = [];
+    for (const h of this.holidays) {
+      const start = startOfDayOrNull(toDate(h.fromDate));
+      const endRaw = startOfDayOrNull(toDate(h.toDate));
+      if (!start || !endRaw) continue;
+      const end = endRaw.getTime() < start.getTime() ? start : endRaw;
+      const hue = hashHue(h.id ?? hashString(h.name));
+
+      for (let w = 0; w < 6; w++) {
+        const week = weeks[w];
+        const wStart = startOfDay(week.days[0].date);
+        const wEnd = startOfDay(week.days[6].date);
+        if (end < wStart || start > wEnd) continue;
+        const segStart = start > wStart ? start : wStart;
+        const segEnd = end < wEnd ? end : wEnd;
+        const startCol = Math.round((segStart.getTime() - wStart.getTime()) / MS_PER_DAY);
+        const endCol = Math.round((segEnd.getTime() - wStart.getTime()) / MS_PER_DAY);
+        segs.push({
+          holiday: h,
+          weekIdx: w,
+          startCol,
+          endCol,
+          startsHere: sameDay(segStart, start),
+          endsHere: sameDay(segEnd, end),
+          length: endCol - startCol + 1,
+          absoluteStart: start.getTime(),
+          hue
+        });
+      }
+    }
+
+    for (let w = 0; w < 6; w++) {
+      const weekSegs = segs
+        .filter((s) => s.weekIdx === w)
+        .map((s) => ({
+          ...s,
+          weight: s.length,
+          tieBreaker: s.absoluteStart
+        }));
+      const { placements, laneCount } = allocateLanes(weekSegs);
+      weeks[w].bars = placements.map(({ item, lane }) => ({
+        holiday: item.holiday,
+        startCol: item.startCol,
+        endCol: item.endCol,
+        lane,
+        startsHere: item.startsHere,
+        endsHere: item.endsHere,
+        hue: item.hue
+      }));
+      weeks[w].laneCount = laneCount;
+    }
+
+    this.weeks = weeks;
+  }
+
+  private computeWeekDayLabels(): string[] {
+    const labels: string[] = [];
+    // Pick a known Sunday (2024-01-07) as the anchor and offset.
+    const anchor = new Date(2024, 0, 7);
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(anchor.getFullYear(), anchor.getMonth(), anchor.getDate() + ((i + this.weekStartsOn) % 7));
+      labels.push(d.toLocaleDateString(undefined, { weekday: 'short' }));
+    }
+    return labels;
+  }
+}
+
+function startOfDayOrNull(d: Date | null): Date | null {
+  return d ? startOfDay(d) : null;
+}

--- a/src/app/organization/holidays/holiday-utils.spec.ts
+++ b/src/app/organization/holidays/holiday-utils.spec.ts
@@ -1,0 +1,134 @@
+import { allocateLanes, hashHue, sameDay, startOfDay, startOfMonth, toDate } from './holiday-utils';
+
+describe('holiday-utils — date helpers', () => {
+  it('toDate parses Mifos [yyyy, mm, dd] arrays', () => {
+    const d = toDate([
+      2026,
+      1,
+      7
+    ]);
+    expect(d).not.toBeNull();
+    expect(d!.getFullYear()).toBe(2026);
+    expect(d!.getMonth()).toBe(0);
+    expect(d!.getDate()).toBe(7);
+  });
+
+  it('toDate accepts Date instances', () => {
+    const original = new Date(2026, 4, 15);
+    expect(toDate(original)).toBe(original);
+  });
+
+  it('toDate accepts ISO strings', () => {
+    expect(toDate('2026-01-07')!.getFullYear()).toBe(2026);
+  });
+
+  it('toDate returns null for null, empty string, or unparseable input', () => {
+    expect(toDate(null)).toBeNull();
+    expect(toDate(undefined)).toBeNull();
+    expect(toDate('')).toBeNull();
+    expect(toDate('not a date')).toBeNull();
+    expect(toDate(new Date('invalid'))).toBeNull();
+  });
+
+  it('startOfDay strips time component', () => {
+    const d = new Date(2026, 0, 7, 14, 35, 22);
+    const s = startOfDay(d);
+    expect(s.getHours()).toBe(0);
+    expect(s.getMinutes()).toBe(0);
+    expect(s.getDate()).toBe(7);
+  });
+
+  it('startOfMonth returns the first day of the month', () => {
+    const d = new Date(2026, 5, 23);
+    expect(startOfMonth(d).getDate()).toBe(1);
+    expect(startOfMonth(d).getMonth()).toBe(5);
+  });
+
+  it('sameDay handles nulls and date equality', () => {
+    expect(sameDay(null, null)).toBe(false);
+    expect(sameDay(new Date(2026, 0, 7), null)).toBe(false);
+    expect(sameDay(new Date(2026, 0, 7), new Date(2026, 0, 7, 23, 59))).toBe(true);
+    expect(sameDay(new Date(2026, 0, 7), new Date(2026, 0, 8))).toBe(false);
+  });
+});
+
+describe('holiday-utils — allocateLanes', () => {
+  it('places non-overlapping items on the same lane', () => {
+    const { placements, laneCount } = allocateLanes([
+      { startCol: 0, endCol: 1 },
+      { startCol: 3, endCol: 4 }
+    ]);
+    expect(laneCount).toBe(1);
+    expect(placements.every((p) => p.lane === 0)).toBe(true);
+  });
+
+  it('stacks overlapping items on separate lanes', () => {
+    const { placements, laneCount } = allocateLanes([
+      { startCol: 0, endCol: 3 },
+      { startCol: 2, endCol: 5 },
+      { startCol: 4, endCol: 6 }
+    ]);
+    expect(laneCount).toBe(2);
+    // Longest item should land on the bottom (lane 0).
+    const bottom = placements.find((p) => p.item.startCol === 0 && p.item.endCol === 3)!;
+    expect(bottom.lane).toBe(0);
+  });
+
+  it('considers two items adjacent (a.endCol === b.startCol) as overlapping', () => {
+    // The greedy check `laneEnds[lane] >= startCol` enforces a 1-cell gap; this
+    // is intentional so visually-touching bars don't render in the same lane.
+    const { laneCount } = allocateLanes([
+      { startCol: 0, endCol: 2 },
+      { startCol: 2, endCol: 4 }
+    ]);
+    expect(laneCount).toBe(2);
+  });
+
+  it('respects weight — heavier items get bottom lane regardless of length', () => {
+    const { placements } = allocateLanes([
+      { startCol: 0, endCol: 6, weight: 1 },
+      { startCol: 2, endCol: 3, weight: 100 }
+    ]);
+    const heavy = placements.find((p) => p.item.weight === 100)!;
+    expect(heavy.lane).toBe(0);
+  });
+
+  it('uses tieBreaker as secondary sort when weights tie', () => {
+    const { placements } = allocateLanes([
+      { startCol: 0, endCol: 2, weight: 5, tieBreaker: 200 },
+      { startCol: 4, endCol: 6, weight: 5, tieBreaker: 100 }
+    ]);
+    // Lower tieBreaker placed first, but since they don't overlap they share lane 0.
+    expect(placements.every((p) => p.lane === 0)).toBe(true);
+  });
+
+  it('returns laneCount=0 for empty input', () => {
+    const { placements, laneCount } = allocateLanes([]);
+    expect(placements).toEqual([]);
+    expect(laneCount).toBe(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { startCol: 4, endCol: 6 },
+      { startCol: 0, endCol: 3 }
+    ];
+    const before = JSON.stringify(input);
+    allocateLanes(input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});
+
+describe('holiday-utils — hashHue', () => {
+  it('always returns a hue in the 200°–340° brand band', () => {
+    for (let i = 0; i < 200; i++) {
+      const h = hashHue(i);
+      expect(h).toBeGreaterThanOrEqual(200);
+      expect(h).toBeLessThan(340);
+    }
+  });
+
+  it('is stable for the same seed', () => {
+    expect(hashHue(42)).toBe(hashHue(42));
+  });
+});

--- a/src/app/organization/holidays/holiday-utils.ts
+++ b/src/app/organization/holidays/holiday-utils.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared utilities for the holidays feature.
+ *
+ * Consolidates date helpers and the calendar's lane-allocation algorithm so
+ * both the page component and the calendar component agree on parsing rules
+ * (especially the Mifos `[year, month, day]` array form returned by the API).
+ */
+
+export interface HolidayStatus {
+  id?: number;
+  code?: string;
+  value?: string;
+}
+
+export interface Holiday {
+  id: number;
+  name: string;
+  fromDate: unknown;
+  toDate: unknown;
+  repaymentsRescheduledTo?: unknown;
+  reschedulingType?: number;
+  status?: HolidayStatus;
+}
+
+export function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1);
+}
+
+export function sameDay(a: Date | null, b: Date | null): boolean {
+  if (!a || !b) return false;
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+/**
+ * Coerce a value to a `Date`. Mifos returns dates as `[yyyy, MM, dd]` arrays in
+ * many places; honour that first. Returns `null` for missing or unparseable input.
+ */
+export function toDate(value: unknown): Date | null {
+  if (value == null || value === '') return null;
+  if (Array.isArray(value) && value.length >= 3) {
+    const [
+      y,
+      m,
+      d
+    ] = value as [number, number, number];
+    return new Date(y, m - 1, d);
+  }
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value;
+  const d = new Date(value as string | number);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/* ------------------------------------------------------------------------- */
+
+/** Input shape for `allocateLanes`. `startCol`/`endCol` are inclusive 0-based positions. */
+export interface LaneCandidate {
+  startCol: number;
+  endCol: number;
+  /** Higher weights are placed first. Defaults to span length when omitted. */
+  weight?: number;
+  /** Sub-sort applied after weight; lower goes first. Useful for stable ordering. */
+  tieBreaker?: number;
+}
+
+/** Result returned by `allocateLanes`. */
+export interface LanePlacement<T extends LaneCandidate> {
+  item: T;
+  lane: number;
+}
+
+/**
+ * Greedily pack candidate spans into the minimum number of lanes such that no
+ * two items in the same lane overlap.
+ *
+ * Items are processed longest-first (or by explicit `weight` desc) so big spans
+ * snag the bottom lane and short ones fill the gaps above. Each lane tracks all
+ * its placed intervals (not just the last `endCol`) so a short span at col 0
+ * can still slot in below an already-placed span at cols 4–6 on the same lane.
+ *
+ * Two spans are considered overlapping when their inclusive ranges share *or*
+ * touch (`a.endCol >= b.startCol - 0` is overlap; we keep a one-cell gap rule —
+ * see the spec — to avoid visually-touching bars on the same lane).
+ *
+ * Pure function — easy to unit test without instantiating Angular components.
+ */
+export function allocateLanes<T extends LaneCandidate>(
+  items: T[]
+): { placements: LanePlacement<T>[]; laneCount: number } {
+  const sorted = [...items].sort((a, b) => {
+    const wa = a.weight ?? a.endCol - a.startCol;
+    const wb = b.weight ?? b.endCol - b.startCol;
+    return wb - wa || (a.tieBreaker ?? 0) - (b.tieBreaker ?? 0) || a.startCol - b.startCol;
+  });
+
+  // For each lane, the list of [startCol, endCol] pairs already placed there.
+  const lanes: Array<Array<[number, number]>> = [];
+  const placements: LanePlacement<T>[] = [];
+
+  const overlapsAny = (lane: Array<[number, number]>, s: number, e: number): boolean => {
+    for (const [
+      ls,
+      le
+    ] of lane) {
+      // Inclusive ranges that share or touch are considered overlapping.
+      if (!(e < ls || s > le)) return true;
+    }
+    return false;
+  };
+
+  for (const item of sorted) {
+    let laneIdx = 0;
+    while (laneIdx < lanes.length && overlapsAny(lanes[laneIdx], item.startCol, item.endCol)) {
+      laneIdx++;
+    }
+    if (laneIdx === lanes.length) lanes.push([]);
+    lanes[laneIdx].push([
+      item.startCol,
+      item.endCol
+    ]);
+    placements.push({ item, lane: laneIdx });
+  }
+
+  placements.sort((a, b) => a.lane - b.lane || a.item.startCol - b.item.startCol);
+  return { placements, laneCount: lanes.length };
+}
+
+/**
+ * Stable seed → hue (degrees) for color-coding events.
+ * Maps into the 200°–340° band so all colors stay brand-adjacent (blues → magentas)
+ * and avoid muddy yellow/green territory.
+ */
+export function hashHue(seed: number): number {
+  const span = 140;
+  const start = 200;
+  return start + (Math.abs(seed) % span);
+}
+
+/** Cheap deterministic string hash. Used as a fallback seed when an entity has no id. */
+export function hashString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}

--- a/src/app/organization/holidays/holidays.component.html
+++ b/src/app/organization/holidays/holidays.component.html
@@ -1,69 +1,184 @@
-<div class="container m-b-20 layout-row align-end gap-20px">
-  <div #buttonCreateHoliday class="in-block">
-    <button mat-raised-button color="primary" [routerLink]="['create']" *mifosxHasPermission="'CREATE_HOLIDAY'">
-      <fa-icon icon="plus" class="m-r-10"></fa-icon>
-      {{ 'labels.buttons.Create Holiday' | translate }}
-    </button>
-  </div>
-</div>
-
-<div class="container">
-  <div #filterRef class="layout-row gap-20px">
-    <mat-form-field class="flex-fill">
-      <mat-label>{{ 'labels.inputs.Filter' | translate }}</mat-label>
-      <input matInput (keyup)="applyFilter($event.target.value)" />
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label> {{ 'labels.inputs.Select Office' | translate }} </mat-label>
-      <mat-select [formControl]="officeSelector">
-        @for (office of officeData; track office) {
-          <mat-option [value]="office.id">
-            {{ office.name }}
-          </mat-option>
+<div class="hl-page">
+  <header class="hl-page-head">
+    <div class="hl-page-titlewrap">
+      <h1 class="hl-page-title">{{ 'labels.heading.Holidays' | translate }}</h1>
+      <p class="hl-page-meta">
+        @if (officeSelector.value) {
+          <span>{{ totalCount }} {{ totalCount === 1 ? 'holiday' : 'holidays' }}</span>
+          <span class="hl-meta-dot">·</span>
+          <span>{{ activeCount }} {{ 'labels.heading.Active' | translate | lowercase }}</span>
+          <span class="hl-meta-dot">·</span>
+          <span>{{ upcomingCount }} {{ 'labels.heading.Upcoming' | translate | lowercase }}</span>
+        } @else {
+          <span class="hl-meta-muted">{{ 'labels.text.Select an office to view holidays' | translate }}</span>
         }
-      </mat-select>
-    </mat-form-field>
-  </div>
+      </p>
+    </div>
 
-  <div class="mat-elevation-z8" [hidden]="!officeSelector.value">
-    <table mat-table [dataSource]="dataSource" matSort>
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Holiday Name' | translate }}</th>
-        <td mat-cell *matCellDef="let holidays">{{ holidays.name }}</td>
-      </ng-container>
+    <div class="hl-page-actions">
+      <mat-form-field appearance="outline" class="hl-office-select">
+        <mat-label>{{ 'labels.inputs.Select Office' | translate }}</mat-label>
+        <mat-select [formControl]="officeSelector">
+          @for (office of officeData; track office.id) {
+            <mat-option [value]="office.id">
+              {{ office.name }}
+            </mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
 
-      <ng-container matColumnDef="fromDate">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Start Date' | translate }}</th>
-        <td mat-cell *matCellDef="let holidays">{{ holidays.fromDate | dateFormat }}</td>
-      </ng-container>
+      <button type="button" class="hl-link-btn" (click)="openAutoImport()" *mifosxHasPermission="'CREATE_HOLIDAY'">
+        <fa-icon icon="cloud-download-alt"></fa-icon>
+        {{ 'labels.buttons.Auto-fill from Google' | translate }}
+      </button>
 
-      <ng-container matColumnDef="toDate">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.End Date' | translate }}</th>
-        <td mat-cell *matCellDef="let holidays">{{ holidays.toDate | dateFormat }}</td>
-      </ng-container>
+      <a
+        mat-flat-button
+        color="primary"
+        class="hl-create-btn"
+        [routerLink]="['create']"
+        *mifosxHasPermission="'CREATE_HOLIDAY'"
+      >
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>
+        {{ 'labels.buttons.Create Holiday' | translate }}
+      </a>
+    </div>
+  </header>
 
-      <ng-container matColumnDef="repaymentsRescheduledTo">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>
-          {{ 'labels.inputs.Repayments Scheduled To' | translate }}
-        </th>
-        <td mat-cell *matCellDef="let holidays">
-          {{
-            holidays.reschedulingType === 1 ? 'Next Repayment Date' : (holidays.repaymentsRescheduledTo | dateFormat)
-          }}
-        </td>
-      </ng-container>
+  @if (officeSelector.value) {
+    <div class="hl-tabs" role="tablist">
+      <button type="button" role="tab" class="hl-tab" [class.is-active]="view === 'month'" (click)="setView('month')">
+        <fa-icon icon="calendar-alt"></fa-icon>
+        {{ 'labels.inputs.Month' | translate }}
+      </button>
+      <button type="button" role="tab" class="hl-tab" [class.is-active]="view === 'list'" (click)="setView('list')">
+        <fa-icon icon="list"></fa-icon>
+        {{ 'labels.inputs.List' | translate }}
+      </button>
 
-      <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Status' | translate }}</th>
-        <td mat-cell *matCellDef="let holidays">{{ holidays.status.value }}</td>
-      </ng-container>
+      @if (view === 'list') {
+        <input
+          type="text"
+          class="hl-list-filter"
+          [placeholder]="'labels.inputs.Filter' | translate"
+          [formControl]="filterControl"
+        />
+      }
+    </div>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="select-row" [routerLink]="[row.id]"></tr>
-    </table>
+    @if (view === 'month') {
+      <mifosx-holiday-calendar
+        [holidays]="holidaysData"
+        [month]="currentMonth"
+        [weekStartsOn]="weekStartsOn"
+        (monthChange)="currentMonth = $event"
+      ></mifosx-holiday-calendar>
+    } @else {
+      @if (filteredHolidays.length === 0) {
+        <div class="hl-empty">
+          @if (filterControl.value) {
+            <p>{{ 'labels.text.No holidays match your filter' | translate }}</p>
+          } @else {
+            <p>{{ 'labels.text.No holidays defined' | translate }}</p>
+          }
+        </div>
+      } @else {
+        <div class="hl-bulkbar" [class.is-active]="selectedIds.size > 0">
+          <label class="hl-bulkbar-select">
+            <mat-checkbox
+              [checked]="allSelected"
+              [indeterminate]="someSelected"
+              (change)="toggleSelectAll($event.checked)"
+            ></mat-checkbox>
+            @if (selectedIds.size > 0) {
+              <span>{{ selectedIds.size }} {{ 'labels.text.selected' | translate }}</span>
+            } @else {
+              <span class="hl-bulkbar-hint">{{ 'labels.text.Select to activate or delete' | translate }}</span>
+            }
+          </label>
 
-    <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
-  </div>
+          @if (selectedIds.size > 0) {
+            <div class="hl-bulkbar-actions">
+              @if (activating) {
+                <span class="hl-bulkbar-progress">
+                  {{ activationProgress.done }} / {{ activationProgress.total }}
+                </span>
+              } @else {
+                <button type="button" class="hl-link-btn-muted" (click)="clearSelection()">
+                  {{ 'labels.buttons.Clear' | translate }}
+                </button>
+                @if (selectedPendingCount > 0) {
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    class="hl-bulkbar-btn"
+                    (click)="activateSelected()"
+                    *mifosxHasPermission="'ACTIVATE_HOLIDAY'"
+                  >
+                    {{ 'labels.buttons.Activate' | translate }} ({{ selectedPendingCount }})
+                  </button>
+                }
+                <button
+                  mat-stroked-button
+                  class="hl-bulkbar-btn hl-bulkbar-btn-danger"
+                  (click)="deleteSelected()"
+                  *mifosxHasPermission="'DELETE_HOLIDAY'"
+                >
+                  {{ 'labels.buttons.Delete' | translate }} ({{ selectedIds.size }})
+                </button>
+              }
+            </div>
+          }
+        </div>
+        <div class="hl-list">
+          @for (group of groupedHolidays; track group.label) {
+            <div class="hl-list-group">
+              <div class="hl-list-group-head">{{ group.label }}</div>
+              @for (h of group.items; track h.id) {
+                <div class="hl-row" [class.is-selected]="isSelected(h.id)">
+                  <mat-checkbox
+                    class="hl-row-check"
+                    [checked]="isSelected(h.id)"
+                    (change)="toggleSelect(h.id)"
+                    (click)="$event.stopPropagation()"
+                  ></mat-checkbox>
+                  <a class="hl-row-body" [routerLink]="[h.id]">
+                    <div class="hl-row-date">
+                      <span class="hl-row-day">{{ formatDay(h.fromDate) }}</span>
+                      <span class="hl-row-mon">{{ formatMonth(h.fromDate) }}</span>
+                    </div>
+                    <div class="hl-row-info">
+                      <div class="hl-row-name">{{ h.name }}</div>
+                      <div class="hl-row-sub">
+                        <span>{{ formatRange(h.fromDate, h.toDate) }}</span>
+                        @if (h.reschedulingType === 1) {
+                          <span class="hl-meta-dot">·</span>
+                          <span>{{ 'labels.inputs.Repayments Scheduled To' | translate }}: next repayment date</span>
+                        } @else if (h.repaymentsRescheduledTo) {
+                          <span class="hl-meta-dot">·</span>
+                          <span
+                            >{{ 'labels.inputs.Repayments Scheduled To' | translate }}:
+                            {{ h.repaymentsRescheduledTo | dateFormat }}</span
+                          >
+                        }
+                      </div>
+                    </div>
+                    <span class="hl-row-status" [ngClass]="statusChipClass(h.status?.value)">
+                      {{ h.status?.value }}
+                    </span>
+                  </a>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      }
+    }
+  } @else {
+    <div class="hl-empty hl-empty-large">
+      <p>{{ 'labels.text.Select an office to view holidays' | translate }}</p>
+    </div>
+  }
 </div>
 
 <ng-template #templateButtonCreateHoliday let-popover="popover">

--- a/src/app/organization/holidays/holidays.component.scss
+++ b/src/app/organization/holidays/holidays.component.scss
@@ -1,7 +1,464 @@
-table {
-  width: 100%;
+:host {
+  display: block;
 
-  .select-row:hover {
-    cursor: pointer;
+  --hl-border: rgb(15 23 42 / 8%);
+  --hl-border-strong: rgb(15 23 42 / 14%);
+  --hl-text: rgb(15 23 42 / 92%);
+  --hl-text-mid: rgb(15 23 42 / 65%);
+  --hl-text-dim: rgb(15 23 42 / 45%);
+  --hl-accent: #1074b9;
+}
+
+.hl-page {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 28px 20px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ---------- Page header ---------- */
+.hl-page-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 18px;
+  border-bottom: 1px solid var(--hl-border);
+  padding-bottom: 16px;
+}
+
+.hl-page-titlewrap {
+  min-width: 0;
+}
+
+.hl-page-title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--hl-text);
+}
+
+.hl-page-meta {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--hl-text-mid);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-feature-settings: 'tnum';
+}
+
+.hl-meta-dot {
+  opacity: 0.4;
+}
+
+.hl-meta-muted {
+  color: var(--hl-text-dim);
+  font-style: italic;
+}
+
+.hl-page-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.hl-office-select {
+  width: 220px;
+}
+
+.hl-office-select.mat-mdc-form-field {
+  margin-bottom: -1.3438em;
+}
+
+.hl-link-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  color: var(--hl-accent);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 6px 4px;
+  border-bottom: 1px solid transparent;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.hl-link-btn:hover {
+  border-bottom-color: var(--hl-accent);
+}
+
+.hl-link-btn fa-icon {
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.hl-create-btn {
+  height: 38px !important;
+  padding: 0 16px !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.01em;
+}
+
+/* ---------- Tabs ---------- */
+.hl-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border-bottom: 1px solid var(--hl-border);
+}
+
+.hl-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 0;
+  padding: 10px 16px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--hl-text-mid);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition:
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.hl-tab:hover {
+  color: var(--hl-text);
+}
+
+.hl-tab.is-active {
+  color: var(--hl-accent);
+  border-bottom-color: var(--hl-accent);
+}
+
+.hl-tab fa-icon {
+  font-size: 12px;
+}
+
+.hl-list-filter {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--hl-border);
+  border-radius: 8px;
+  padding: 7px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--hl-text);
+  width: 220px;
+  outline: none;
+  transition: border-color 0.12s ease;
+}
+
+.hl-list-filter:focus {
+  border-color: var(--hl-accent);
+}
+
+.hl-list-filter::placeholder {
+  color: var(--hl-text-dim);
+}
+
+/* ---------- List view ---------- */
+.hl-list {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.hl-list-group-head {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hl-text-dim);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--hl-border);
+  margin-bottom: 4px;
+  position: sticky;
+  top: 0;
+  background: rgb(255 255 255 / 92%);
+  backdrop-filter: blur(6px);
+  z-index: 2;
+}
+
+/* ---------- Bulk action bar ---------- */
+.hl-bulkbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 12px;
+  border: 1px solid var(--hl-border);
+  border-radius: 8px;
+  margin-bottom: 8px;
+  background: rgb(15 23 42 / 2%);
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.hl-bulkbar.is-active {
+  border-color: rgb(16 116 185 / 35%);
+  background: rgb(16 116 185 / 6%);
+}
+
+.hl-bulkbar-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--hl-text-mid);
+  cursor: pointer;
+}
+
+.hl-bulkbar-hint {
+  color: var(--hl-text-dim);
+}
+
+.hl-bulkbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.hl-bulkbar-progress {
+  font-size: 13px;
+  color: var(--hl-text-mid);
+  font-feature-settings: 'tnum';
+}
+
+.hl-bulkbar-btn {
+  height: 32px !important;
+  padding: 0 14px !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+}
+
+.hl-bulkbar-btn-danger {
+  color: #b91c1c !important;
+  border-color: rgb(220 38 38 / 35%) !important;
+}
+
+.hl-bulkbar-btn-danger:hover {
+  background: rgb(220 38 38 / 6%) !important;
+  border-color: rgb(220 38 38 / 60%) !important;
+}
+
+.hl-link-btn-muted {
+  background: transparent;
+  border: 0;
+  color: var(--hl-text-mid);
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 6px 4px;
+  text-decoration: underline;
+  text-decoration-color: rgb(15 23 42 / 20%);
+  text-underline-offset: 3px;
+}
+
+.hl-link-btn-muted:hover {
+  color: var(--hl-text);
+  text-decoration-color: var(--hl-text);
+}
+
+/* ---------- Row ---------- */
+.hl-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--hl-border);
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.hl-row.is-selected {
+  background: rgb(16 116 185 / 5%);
+  border-color: rgb(16 116 185 / 25%);
+}
+
+.hl-row:hover {
+  background: rgb(16 116 185 / 4%);
+}
+
+.hl-row-check,
+.hl-row-check-spacer {
+  flex: 0 0 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 4px;
+}
+
+.hl-row-body {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 8px;
+  text-decoration: none;
+  color: inherit;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.hl-row-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1;
+  flex: 0 0 56px;
+}
+
+.hl-row-day {
+  font-size: 22px;
+  font-weight: 600;
+  font-feature-settings: 'tnum';
+  color: var(--hl-text);
+}
+
+.hl-row-mon {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--hl-text-dim);
+  margin-top: 4px;
+}
+
+.hl-row-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.hl-row-name {
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--hl-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hl-row-sub {
+  font-size: 12px;
+  color: var(--hl-text-mid);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.hl-row-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgb(15 23 42 / 5%);
+  color: var(--hl-text-mid);
+}
+
+.hl-row-status.is-active {
+  background: rgb(46 125 50 / 12%);
+  color: #2e7d32;
+}
+
+.hl-row-status.is-pending {
+  background: rgb(245 158 11 / 14%);
+  color: #b45309;
+}
+
+.hl-row-status.is-deleted {
+  background: rgb(220 38 38 / 10%);
+  color: #b91c1c;
+}
+
+/* ---------- Empty ---------- */
+.hl-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--hl-text-dim);
+  font-size: 14px;
+}
+
+.hl-empty-large {
+  padding: 96px 16px;
+  font-size: 15px;
+}
+
+.hl-empty p {
+  margin: 0;
+}
+
+/* ---------- Dark mode ---------- */
+:host-context(.dark-mode),
+:host-context([data-theme='dark']) {
+  --hl-border: rgb(255 255 255 / 8%);
+  --hl-border-strong: rgb(255 255 255 / 16%);
+  --hl-text: rgb(255 255 255 / 92%);
+  --hl-text-mid: rgb(255 255 255 / 65%);
+  --hl-text-dim: rgb(255 255 255 / 45%);
+}
+
+:host-context(.dark-mode) .hl-list-group-head,
+:host-context([data-theme='dark']) .hl-list-group-head {
+  background: rgb(20 28 40 / 92%);
+}
+
+:host-context(.dark-mode) .hl-row:hover,
+:host-context([data-theme='dark']) .hl-row:hover {
+  background: rgb(91 162 236 / 8%);
+}
+
+/* ---------- Responsive ---------- */
+@media (width <= 720px) {
+  .hl-page-actions {
+    width: 100%;
+  }
+
+  .hl-office-select {
+    flex: 1 1 auto;
+    width: auto;
+  }
+
+  .hl-row-body {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .hl-row-date {
+    flex: 0 0 48px;
+  }
+
+  .hl-row-status {
+    flex-basis: 100%;
+    margin-left: 66px;
+  }
+
+  .hl-list-filter {
+    width: 100%;
+    margin-left: 0;
   }
 }

--- a/src/app/organization/holidays/holidays.component.ts
+++ b/src/app/organization/holidays/holidays.component.ts
@@ -1,58 +1,55 @@
-/** Angular Imports */
-import { Component, OnInit, TemplateRef, ElementRef, ViewChild, AfterViewInit, inject } from '@angular/core';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
-  MatTableDataSource,
-  MatTable,
-  MatColumnDef,
-  MatHeaderCellDef,
-  MatHeaderCell,
-  MatCellDef,
-  MatCell,
-  MatHeaderRowDef,
-  MatHeaderRow,
-  MatRowDef,
-  MatRow
-} from '@angular/material/table';
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+  inject
+} from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { CommonModule } from '@angular/common';
+import { TranslateService } from '@ngx-translate/core';
+import { from, of } from 'rxjs';
 
-/** rxjs Imports */
-import { of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, map, mergeMap, tap } from 'rxjs/operators';
 
-/** Custom Services */
 import { OrganizationService } from '../organization.service';
 import { PopoverService } from '../../configuration-wizard/popover/popover.service';
 import { ConfigurationWizardService } from '../../configuration-wizard/configuration-wizard.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { ConfirmationDialogComponent } from '../../shared/confirmation-dialog/confirmation-dialog.component';
+import { HolidayAutoImportDialogComponent } from './holiday-auto-import-dialog/holiday-auto-import-dialog.component';
+import { HolidayCalendarComponent } from './holiday-calendar/holiday-calendar.component';
+import { Holiday, sameDay, startOfDay, startOfMonth, toDate } from './holiday-utils';
 
-/**
- * Holidays component.
- */
+interface HolidayGroup {
+  label: string;
+  items: Holiday[];
+}
+
+/** Egypt-conventional Saturday-first display in the calendar. */
+const WEEK_STARTS_ON = 6;
+
 @Component({
   selector: 'mifosx-holidays',
   templateUrl: './holidays.component.html',
   styleUrls: ['./holidays.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
+    CommonModule,
     FaIconComponent,
-    MatTable,
-    MatSort,
-    MatColumnDef,
-    MatHeaderCellDef,
-    MatHeaderCell,
-    MatSortHeader,
-    MatCellDef,
-    MatCell,
-    MatHeaderRowDef,
-    MatHeaderRow,
-    MatRowDef,
-    MatRow,
-    MatPaginator,
-    DateFormatPipe
+    DateFormatPipe,
+    HolidayCalendarComponent,
+    MatCheckbox
   ]
 })
 export class HolidaysComponent implements OnInit, AfterViewInit {
@@ -61,97 +58,334 @@ export class HolidaysComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private dialog = inject(MatDialog);
+  private cdr = inject(ChangeDetectorRef);
+  private translate = inject(TranslateService);
 
   /** Office selector. */
   officeSelector = new UntypedFormControl();
-  /** Holidays data. */
-  holidaysData: any;
+  /** List-view filter. */
+  filterControl = new UntypedFormControl('');
+
+  /** All holidays for the selected office (excluding deleted). */
+  holidaysData: Holiday[] = [];
+  /** Filtered subset shown in the list view. */
+  filteredHolidays: Holiday[] = [];
+  /** List view rows grouped by month label. */
+  groupedHolidays: HolidayGroup[] = [];
+
+  /** Memoized counts; updated only when data reloads. */
+  totalCount = 0;
+  activeCount = 0;
+  upcomingCount = 0;
+
   /** Offices data. */
-  officeData: any;
-  /** Columns to be displayed in holidays table. */
-  displayedColumns: string[] = [
-    'name',
-    'fromDate',
-    'toDate',
-    'repaymentsRescheduledTo',
-    'status'
-  ];
-  /** Data source for holidays table. */
-  dataSource: MatTableDataSource<any>;
+  officeData: { id: number; name: string }[] = [];
 
-  /** Paginator for holidays table. */
-  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
-  /** Sorter for holidays table. */
-  @ViewChild(MatSort, { static: true }) sort: MatSort;
+  /** Active view tab. */
+  view: 'month' | 'list' = 'month';
+  /** Current month displayed by the calendar. */
+  currentMonth = startOfMonth(new Date());
+  /** Saturday-first week display in the calendar. */
+  readonly weekStartsOn = WEEK_STARTS_ON;
 
-  /* Reference of create holiday button */
+  /** IDs selected for bulk activation in the list view. */
+  selectedIds = new Set<number>();
+  /** Bulk-activation progress + state. */
+  activating = false;
+  activationProgress = { done: 0, total: 0 };
+  /** True when the list view's derived state needs recompute on next access. */
+  private listViewDirty = true;
+
+  /* Reference of create holiday button (configuration wizard). */
   @ViewChild('buttonCreateHoliday') buttonCreateHoliday: ElementRef<any>;
-  /* Template for popover on create holiday button */
   @ViewChild('templateButtonCreateHoliday') templateButtonCreateHoliday: TemplateRef<any>;
-  /* Reference of filter */
   @ViewChild('filterRef') filterRef: ElementRef<any>;
-  /* Template to show popover on filter */
   @ViewChild('templateFilterRef') templateFilterRef: TemplateRef<any>;
 
-  /**
-   * Retrieves the offices data from `resolve`.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {Router} router Router.
-   * @param {ConfigurationWizardService} configurationWizardService ConfigurationWizard Service.
-   * @param {PopoverService} popoverService PopoverService.
-   */
   constructor() {
     this.route.data.subscribe((data: { offices: any }) => {
-      this.officeData = data.offices;
+      this.officeData = data.offices ?? [];
     });
   }
 
-  /**
-   * Filters data in holidays table based on passed value.
-   * @param {string} filterValue Value to filter data.
-   */
-  applyFilter(filterValue: string) {
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+  ngOnInit(): void {
+    this.officeSelector.valueChanges.subscribe((officeId) => {
+      this.loadHolidays(officeId);
+    });
+    // Debounce list filter so typing doesn't iterate the array on every keystroke.
+    this.filterControl.valueChanges.pipe(debounceTime(150), distinctUntilChanged()).subscribe(() => {
+      this.listViewDirty = true;
+      if (this.view === 'list') this.recomputeListView();
+      this.cdr.markForCheck();
+    });
+    // Auto-select the first office so the page lands on data instead of an empty state.
+    if (this.officeData.length > 0 && this.officeSelector.value == null) {
+      this.officeSelector.setValue(this.officeData[0].id);
+    }
   }
 
-  /**
-   * Retrieves holidays data on changing office.
-   */
-  ngOnInit() {
-    this.onChangeOffice();
-  }
-
-  /**
-   * Retrieves the holidays data on changing office and sets the holidays table.
-   */
-  onChangeOffice() {
-    this.officeSelector.valueChanges.subscribe((officeId = this.officeSelector.value) => {
+  /** Fetch holidays and recompute all derived state in one pass. */
+  loadHolidays(officeId: number | string | null | undefined): void {
+    if (officeId == null) {
       this.holidaysData = [];
-      this.organizationService.getHolidays(officeId).subscribe((holidays: any) => {
-        this.holidaysData = holidays.filter((holiday: any) => holiday.status.value !== 'Deleted');
-        this.setHolidays();
-      });
+      this.selectedIds = new Set();
+      this.recomputeAll();
+      this.cdr.markForCheck();
+      return;
+    }
+    this.organizationService.getHolidays(officeId as string).subscribe((holidays: Holiday[] | null) => {
+      this.holidaysData = (holidays ?? []).filter((h) => h?.status?.value !== 'Deleted');
+      // Drop any selections that no longer exist in the refreshed data set.
+      const existing = new Set(this.holidaysData.map((h) => h.id));
+      this.selectedIds = new Set([...this.selectedIds].filter((id) => existing.has(id)));
+      this.recomputeAll();
+      this.cdr.markForCheck();
     });
   }
 
-  /**
-   * Initializes the data source, paginator and sorter for holidays table.
-   */
-  setHolidays() {
-    this.dataSource = new MatTableDataSource(this.holidaysData);
-    this.dataSource.paginator = this.paginator;
-    this.dataSource.sort = this.sort;
+  /** Whether a holiday can be activated (status is "Pending for activation"). */
+  canActivate(h: Holiday): boolean {
+    const v = (h?.status?.value ?? '').toString().toLowerCase();
+    return v === 'pending for activation' || v === 'pending';
+  }
+
+  /** True if every row in the current filtered view is selected. */
+  get allSelected(): boolean {
+    return this.filteredHolidays.length > 0 && this.filteredHolidays.every((h) => this.selectedIds.has(h.id));
+  }
+
+  /** True if some — but not all — rows in the filtered view are selected. */
+  get someSelected(): boolean {
+    return this.selectedIds.size > 0 && !this.allSelected;
+  }
+
+  /** Count of currently-selected rows whose status is "Pending for activation". */
+  get selectedPendingCount(): number {
+    let n = 0;
+    for (const h of this.filteredHolidays) {
+      if (this.selectedIds.has(h.id) && this.canActivate(h)) n++;
+    }
+    return n;
+  }
+
+  isSelected(id: number): boolean {
+    return this.selectedIds.has(id);
+  }
+
+  toggleSelect(id: number): void {
+    // Build a new Set so OnPush change detection picks up the identity change.
+    const next = new Set(this.selectedIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    this.selectedIds = next;
+  }
+
+  toggleSelectAll(checked: boolean): void {
+    this.selectedIds = checked ? new Set(this.filteredHolidays.map((h) => h.id)) : new Set();
+  }
+
+  clearSelection(): void {
+    this.selectedIds = new Set();
   }
 
   /**
-   * Popover function
-   * @param template TemplateRef<any>.
-   * @param target HTMLElement | ElementRef<any>.
-   * @param position String.
-   * @param backdrop Boolean.
+   * Activate every selected holiday whose status is "Pending for activation".
+   * Active/already-activated rows in the selection are skipped (the API would
+   * reject them); the confirmation dialog tells the user when that's happening
+   * so they're not surprised by a "4 of 10" outcome.
    */
+  activateSelected(): void {
+    if (this.activating) return;
+    const ids = this.filteredHolidays.filter((h) => this.selectedIds.has(h.id) && this.canActivate(h)).map((h) => h.id);
+    if (ids.length === 0) return;
+    const skipped = this.selectedIds.size - ids.length;
+
+    let dialogContext =
+      this.translate.instant('labels.dialogContext.Are you sure you want to activate') +
+      ` ${ids.length} ` +
+      this.translate.instant('labels.dialogContext.holiday');
+    if (skipped > 0) {
+      dialogContext += '. ' + skipped + ' ' + this.translate.instant('labels.text.already-active rows will be skipped');
+    }
+
+    const ref = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        heading: this.translate.instant('labels.heading.Holidays'),
+        dialogContext
+      }
+    });
+
+    ref.afterClosed().subscribe((result: { confirm?: boolean } | undefined) => {
+      if (!result?.confirm) return;
+      this.runBulk(ids, 'activate');
+    });
+  }
+
+  /** Delete every selected holiday. Confirmation required. */
+  deleteSelected(): void {
+    if (this.activating) return;
+    const ids = Array.from(this.selectedIds);
+    if (ids.length === 0) return;
+
+    const ref = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        heading: this.translate.instant('labels.heading.Holidays'),
+        dialogContext:
+          this.translate.instant('labels.dialogContext.Are you sure you want to delete') +
+          ` ${ids.length} ` +
+          this.translate.instant('labels.dialogContext.holiday'),
+        type: 'danger'
+      }
+    });
+
+    ref.afterClosed().subscribe((result: { confirm?: boolean } | undefined) => {
+      if (!result?.confirm) return;
+      this.runBulk(ids, 'delete');
+    });
+  }
+
+  private runBulk(ids: number[], action: 'activate' | 'delete'): void {
+    this.activating = true;
+    this.activationProgress = { done: 0, total: ids.length };
+    let success = 0;
+    let failed = 0;
+
+    const op = (id: number) =>
+      action === 'activate'
+        ? this.organizationService.activateHoliday(String(id))
+        : this.organizationService.deleteHoliday(String(id));
+
+    from(ids)
+      .pipe(
+        mergeMap(
+          (id) =>
+            op(id).pipe(
+              map(() => true),
+              catchError(() => of(false))
+            ),
+          3
+        ),
+        tap((ok) => {
+          if (ok) success++;
+          else failed++;
+          this.activationProgress = { done: success + failed, total: ids.length };
+          this.cdr.markForCheck();
+        }),
+        finalize(() => {
+          this.activating = false;
+          this.clearSelection();
+          if (this.officeSelector.value != null) {
+            this.loadHolidays(this.officeSelector.value);
+          } else {
+            this.cdr.markForCheck();
+          }
+        })
+      )
+      .subscribe();
+  }
+
+  /** Single recompute for counts + list view. Called only on data change. */
+  private recomputeAll(): void {
+    const today = startOfDay(new Date());
+    let active = 0;
+    let upcoming = 0;
+    for (const h of this.holidaysData) {
+      if (h?.status?.value === 'Active') active++;
+      const start = toDate(h?.fromDate);
+      if (start && startOfDay(start).getTime() >= today.getTime()) upcoming++;
+    }
+    this.totalCount = this.holidaysData.length;
+    this.activeCount = active;
+    this.upcomingCount = upcoming;
+    this.recomputeListView();
+  }
+
+  private recomputeListView(): void {
+    const filter = (this.filterControl.value ?? '').toString().trim().toLowerCase();
+    const filtered = filter
+      ? this.holidaysData.filter((h) => (h?.name ?? '').toString().toLowerCase().includes(filter))
+      : this.holidaysData.slice();
+    // Sort newest-first by start date for list view.
+    filtered.sort((a, b) => {
+      const da = toDate(a?.fromDate)?.getTime() ?? 0;
+      const db = toDate(b?.fromDate)?.getTime() ?? 0;
+      return db - da;
+    });
+    this.filteredHolidays = filtered;
+
+    const groups = new Map<string, any[]>();
+    for (const h of filtered) {
+      const d = toDate(h?.fromDate);
+      const label = d ? d.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }) : 'Unknown';
+      const list = groups.get(label) ?? [];
+      list.push(h);
+      groups.set(label, list);
+    }
+    this.groupedHolidays = Array.from(groups.entries()).map(
+      ([
+        label,
+        items
+      ]) => ({ label, items })
+    );
+  }
+
+  setView(view: 'month' | 'list'): void {
+    this.view = view;
+    if (view === 'list' && this.listViewDirty) {
+      this.recomputeListView();
+    }
+  }
+
+  statusChipClass(value: string | undefined): string {
+    if (!value) return '';
+    const v = value.toLowerCase();
+    if (v === 'active') return 'is-active';
+    if (v === 'pending for activation' || v === 'pending') return 'is-pending';
+    if (v === 'deleted') return 'is-deleted';
+    return '';
+  }
+
+  formatDay(value: unknown): string {
+    const d = toDate(value);
+    return d ? String(d.getDate()) : '';
+  }
+
+  formatMonth(value: unknown): string {
+    const d = toDate(value);
+    return d ? d.toLocaleDateString(undefined, { month: 'short' }) : '';
+  }
+
+  formatRange(from: unknown, to: unknown): string {
+    const start = toDate(from);
+    const end = toDate(to);
+    if (!start) return '';
+    const fmt: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+    if (!end || sameDay(start, end)) {
+      return start.toLocaleDateString(undefined, fmt);
+    }
+    return `${start.toLocaleDateString(undefined, fmt)} – ${end.toLocaleDateString(undefined, fmt)}`;
+  }
+
+  /** Opens the Google Calendar holiday auto-import dialog. */
+  openAutoImport(): void {
+    const ref = this.dialog.open(HolidayAutoImportDialogComponent, {
+      width: '720px',
+      maxWidth: '95vw',
+      data: {
+        offices: this.officeData,
+        defaultOfficeId: this.officeSelector.value
+      }
+    });
+    ref.afterClosed().subscribe((result: { imported: boolean } | undefined) => {
+      if (result?.imported && this.officeSelector.value) {
+        this.loadHolidays(this.officeSelector.value);
+      }
+    });
+  }
+
+  /* ---------- Configuration wizard hooks (unchanged behaviour). ---------- */
+
   showPopover(
     template: TemplateRef<any>,
     target: HTMLElement | ElementRef<any>,
@@ -161,37 +395,27 @@ export class HolidaysComponent implements OnInit, AfterViewInit {
     setTimeout(() => this.popoverService.open(template, target, position, backdrop, {}), 200);
   }
 
-  /**
-   * To show popover.
-   */
-  ngAfterViewInit() {
+  ngAfterViewInit(): void {
     if (this.configurationWizardService.showHolidayPage === true) {
       setTimeout(() => {
-        this.showPopover(this.templateButtonCreateHoliday, this.buttonCreateHoliday.nativeElement, 'bottom', true);
+        this.showPopover(this.templateButtonCreateHoliday, this.buttonCreateHoliday?.nativeElement, 'bottom', true);
       });
     }
-
     if (this.configurationWizardService.showHolidayFilter === true) {
       setTimeout(() => {
-        this.showPopover(this.templateFilterRef, this.filterRef.nativeElement, 'bottom', true);
+        this.showPopover(this.templateFilterRef, this.filterRef?.nativeElement, 'bottom', true);
       });
     }
   }
 
-  /**
-   * Next Step (Create Employee) Configuration Wizard.
-   */
-  nextStep() {
+  nextStep(): void {
     this.configurationWizardService.showHolidayPage = false;
     this.configurationWizardService.showHolidayFilter = false;
     this.configurationWizardService.showCreateEmployee = true;
     this.router.navigate(['/organization']);
   }
 
-  /**
-   * Previous Step (Manage Holidays) Configuration Wizard.
-   */
-  previousStep() {
+  previousStep(): void {
     this.configurationWizardService.showHolidayPage = false;
     this.configurationWizardService.showHolidayFilter = false;
     this.configurationWizardService.showCreateHoliday = true;

--- a/src/app/organization/working-days/working-days.component.html
+++ b/src/app/organization/working-days/working-days.component.html
@@ -1,51 +1,85 @@
-<div class="container">
-  <mat-card>
-    <form [formGroup]="workingDaysForm" (ngSubmit)="submit()">
-      <mat-card-content>
-        <div #workingDaysFormRef class="layout-column">
-          <div class="layout-row responsive-column">
-            <mat-label class="mat-h4 flex-50">{{ 'labels.inputs.Working Days' | translate }}</mat-label>
-            <div class="flex-50 layout-column" formArrayName="recurrence">
-              @for (day of recurrence.controls; track day; let i = $index) {
-                <div>
-                  <mat-checkbox labelPosition="after" [formControlName]="i">
-                    {{ weekDays[i].name }}
-                  </mat-checkbox>
-                </div>
-              }
-            </div>
-          </div>
+<div class="wd-page">
+  <header class="wd-page-head">
+    <div>
+      <h1 class="wd-page-title">{{ 'labels.heading.Working Days' | translate }}</h1>
+      <p class="wd-page-meta">
+        <span>{{ activeDayCount }}</span>
+        <span class="wd-meta-sep">/</span>
+        <span>7 days</span>
+        <span class="wd-meta-dot">·</span>
+        <span class="wd-meta-list">{{ activeDayList }}</span>
+      </p>
+    </div>
+  </header>
 
-          <mat-form-field>
-            <mat-label>{{ 'labels.inputs.Payments due on non working days' | translate }}</mat-label>
-            <mat-select formControlName="repaymentRescheduleType">
-              @for (repaymentRescheduleType of repaymentRescheduleTypeData; track repaymentRescheduleType) {
-                <mat-option [value]="repaymentRescheduleType.id">
-                  {{ repaymentRescheduleType.value }}
-                </mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
+  <form [formGroup]="workingDaysForm" (ngSubmit)="submit()" class="wd-form">
+    <section #workingDaysFormRef class="wd-section">
+      <div class="wd-section-head">
+        <h2 class="wd-section-title">{{ 'labels.inputs.Working Days' | translate }}</h2>
+        <p class="wd-section-hint">{{ 'labels.text.Tap a day to toggle' | translate }}</p>
+      </div>
 
-          <mat-checkbox labelPosition="before" formControlName="extendTermForDailyRepayments">
-            {{ 'labels.inputs.Loans daily repayment schedule' | translate }}
-          </mat-checkbox>
-        </div>
-      </mat-card-content>
+      <div class="wd-pills" formArrayName="recurrence">
+        @for (day of recurrence.controls; track $index; let i = $index) {
+          <button
+            type="button"
+            class="wd-pill"
+            [class.is-active]="day.value"
+            [attr.aria-pressed]="!!day.value"
+            [attr.aria-label]="weekDays[i].name"
+            (click)="toggleDay(i)"
+          >
+            {{ weekDays[i].name.slice(0, 3) }}
+          </button>
+        }
+      </div>
+    </section>
 
-      <mat-card-actions class="layout-row align-center gap-5px responsive-column">
-        <button mat-raised-button [routerLink]="['../']">{{ 'labels.buttons.Cancel' | translate }}</button>
-        <button
-          mat-raised-button
-          color="primary"
-          [disabled]="workingDaysForm.pristine"
-          *mifosxHasPermission="'UPDATE_WORKINGDAYS'"
-        >
-          {{ 'labels.buttons.Submit' | translate }}
-        </button>
-      </mat-card-actions>
-    </form>
-  </mat-card>
+    <section class="wd-section">
+      <div class="wd-section-head">
+        <h2 class="wd-section-title">{{ 'labels.inputs.Payments due on non working days' | translate }}</h2>
+        <p class="wd-section-hint">
+          {{ 'labels.text.Configure how payments due on non-working days behave' | translate }}
+        </p>
+      </div>
+
+      <div class="wd-fields">
+        <mat-form-field appearance="outline" class="wd-field">
+          <mat-label>{{ 'labels.inputs.Payments due on non working days' | translate }}</mat-label>
+          <mat-select formControlName="repaymentRescheduleType">
+            @for (repaymentRescheduleType of repaymentRescheduleTypeData; track repaymentRescheduleType.id) {
+              <mat-option [value]="repaymentRescheduleType.id">
+                {{ repaymentRescheduleType.value }}
+              </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <label class="wd-toggle">
+          <mat-checkbox formControlName="extendTermForDailyRepayments"></mat-checkbox>
+          <span>{{ 'labels.inputs.Loans daily repayment schedule' | translate }}</span>
+        </label>
+      </div>
+    </section>
+
+    <div class="wd-actions">
+      @if (workingDaysForm.pristine) {
+        <span class="wd-actions-hint">{{ 'labels.text.No changes to save' | translate }}</span>
+      }
+      <button mat-stroked-button type="button" [routerLink]="['../']">
+        {{ 'labels.buttons.Cancel' | translate }}
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        type="submit"
+        [disabled]="workingDaysForm.pristine"
+        *mifosxHasPermission="'UPDATE_WORKINGDAYS'"
+      >
+        {{ 'labels.buttons.Submit' | translate }}
+      </button>
+    </div>
+  </form>
 </div>
 
 <ng-template #templateWorkingDaysFormRef let-data let-popover="popover">

--- a/src/app/organization/working-days/working-days.component.scss
+++ b/src/app/organization/working-days/working-days.component.scss
@@ -1,3 +1,223 @@
-.container {
-  max-width: 37rem;
+:host {
+  display: block;
+}
+
+/* ---------- Page ---------- */
+.wd-page {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.wd-page-head {
+  border-bottom: 1px solid rgb(15 23 42 / 8%);
+  padding-bottom: 18px;
+}
+
+.wd-page-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: rgb(15 23 42 / 92%);
+  font-feature-settings: 'ss01';
+}
+
+.wd-page-meta {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: rgb(15 23 42 / 55%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.wd-page-meta > span:first-child {
+  color: #1074b9;
+  font-weight: 600;
+}
+
+.wd-meta-sep {
+  opacity: 0.45;
+}
+
+.wd-meta-dot {
+  opacity: 0.4;
+  margin: 0 2px;
+}
+
+.wd-meta-list {
+  font-feature-settings: 'tnum';
+}
+
+/* ---------- Form ---------- */
+.wd-form {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.wd-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.wd-section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.wd-section-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(15 23 42 / 70%);
+}
+
+.wd-section-hint {
+  margin: 0;
+  font-size: 13px;
+  color: rgb(15 23 42 / 50%);
+}
+
+/* ---------- Day pills ---------- */
+.wd-pills {
+  display: flex;
+  gap: 8px;
+}
+
+.wd-pill {
+  flex: 1 1 0;
+  position: relative;
+  border: 1px solid rgb(15 23 42 / 12%);
+  background: rgb(15 23 42 / 2.5%);
+  border-radius: 10px;
+  padding: 16px 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgb(15 23 42 / 65%);
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease,
+    background 0.12s ease,
+    transform 0.12s ease;
+}
+
+.wd-pill:hover {
+  border-color: rgb(16 116 185 / 50%);
+  background: rgb(16 116 185 / 5%);
+  color: rgb(15 23 42 / 92%);
+}
+
+.wd-pill:active {
+  transform: scale(0.97);
+}
+
+.wd-pill:focus-visible {
+  outline: none;
+  border-color: #1074b9;
+  box-shadow: 0 0 0 3px rgb(16 116 185 / 25%);
+}
+
+.wd-pill.is-active {
+  background: #1074b9;
+  border-color: #1074b9;
+  color: #fff;
+}
+
+.wd-pill.is-active:hover {
+  background: #0d6aaa;
+  border-color: #0d6aaa;
+}
+
+/* ---------- Fields ---------- */
+.wd-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.wd-field {
+  width: 100%;
+}
+
+.wd-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: rgb(15 23 42 / 80%);
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+/* ---------- Actions ---------- */
+.wd-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  border-top: 1px solid rgb(15 23 42 / 8%);
+  padding-top: 18px;
+}
+
+.wd-actions-hint {
+  font-size: 12px;
+  color: rgb(15 23 42 / 45%);
+  margin-right: auto;
+  font-style: italic;
+}
+
+/* ---------- Dark mode ---------- */
+:host-context(.dark-mode) .wd-page-title,
+:host-context([data-theme='dark']) .wd-page-title {
+  color: rgb(255 255 255 / 92%);
+}
+
+:host-context(.dark-mode) .wd-pill,
+:host-context([data-theme='dark']) .wd-pill {
+  border-color: rgb(255 255 255 / 14%);
+  background: rgb(255 255 255 / 3%);
+  color: rgb(255 255 255 / 65%);
+}
+
+:host-context(.dark-mode) .wd-pill:hover,
+:host-context([data-theme='dark']) .wd-pill:hover {
+  border-color: rgb(91 162 236 / 60%);
+  background: rgb(91 162 236 / 8%);
+  color: rgb(255 255 255 / 92%);
+}
+
+:host-context(.dark-mode) .wd-section-title,
+:host-context([data-theme='dark']) .wd-section-title {
+  color: rgb(255 255 255 / 72%);
+}
+
+:host-context(.dark-mode) .wd-page-head,
+:host-context([data-theme='dark']) .wd-page-head,
+:host-context(.dark-mode) .wd-actions,
+:host-context([data-theme='dark']) .wd-actions {
+  border-color: rgb(255 255 255 / 8%);
+}
+
+/* ---------- Responsive ---------- */
+@media (width <= 600px) {
+  .wd-page {
+    padding: 28px 16px 48px;
+  }
+
+  .wd-pill {
+    font-size: 13px;
+    padding: 14px 4px;
+  }
 }

--- a/src/app/organization/working-days/working-days.component.ts
+++ b/src/app/organization/working-days/working-days.component.ts
@@ -50,15 +50,15 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
   workingDaysForm: UntypedFormGroup;
   /** Working days data. */
   workingDaysData: any;
-  /** Week days */
+  /** Week days. Ordered Saturday-first to match the locale convention. */
   weekDays = [
+    { name: 'Saturday', value: 'SA', checked: false },
+    { name: 'Sunday', value: 'SU', checked: false },
     { name: 'Monday', value: 'MO', checked: false },
     { name: 'Tuesday', value: 'TU', checked: false },
     { name: 'Wednesday', value: 'WE', checked: false },
     { name: 'Thursday', value: 'TH', checked: false },
-    { name: 'Friday', value: 'FR', checked: false },
-    { name: 'Saturday', value: 'SA', checked: false },
-    { name: 'Sunday', value: 'SU', checked: false }
+    { name: 'Friday', value: 'FR', checked: false }
   ];
   /**  Repayment schedule type data. */
   repaymentRescheduleTypeData: any;
@@ -110,6 +110,38 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
    */
   get recurrence(): UntypedFormArray {
     return this.workingDaysForm.get('recurrence') as UntypedFormArray;
+  }
+
+  /** Number of currently selected working days. */
+  get activeDayCount(): number {
+    if (!this.workingDaysForm) {
+      return this.weekDays.filter((d) => d.checked).length;
+    }
+    return this.recurrence.controls.filter((c) => !!c.value).length;
+  }
+
+  /** Comma-separated short names of active days, e.g. "Mon, Tue, Wed". */
+  get activeDayList(): string {
+    if (!this.workingDaysForm) {
+      return this.weekDays
+        .filter((d) => d.checked)
+        .map((d) => d.name.slice(0, 3))
+        .join(', ');
+    }
+    return this.recurrence.controls
+      .map((c, i) => (c.value ? this.weekDays[i].name.slice(0, 3) : null))
+      .filter((n): n is string => !!n)
+      .join(', ');
+  }
+
+  /**
+   * Toggle a day pill. Marks the form dirty so the submit button enables.
+   */
+  toggleDay(index: number): void {
+    const ctrl = this.recurrence.at(index);
+    ctrl.setValue(!ctrl.value);
+    ctrl.markAsDirty();
+    this.workingDaysForm.markAsDirty();
   }
 
   /**

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -540,7 +540,16 @@
       "Withdraw": "Withdraw",
       "View Active Charges": "View Active Charges",
       "View Inactive Charges": "View Inactive Charges",
-      "Yes": "Yes"
+      "Yes": "Yes",
+      "Auto-fill from Google": "Auto-fill from Google",
+      "Done": "Done",
+      "Import": "Import",
+      "Retry": "Retry",
+      "Today": "Today",
+      "Previous month": "Previous month",
+      "Next month": "Next month",
+      "Activate selected": "Activate selected",
+      "Clear": "Clear"
     },
     "catalogs": {
       "Interest payment waiver": "Interest Payment Waiver",
@@ -1198,7 +1207,12 @@
       "Not Yet Amortized Amount": "Not Yet Amortized Amount",
       "Adjusted Amount": "Adjusted Amount",
       "Charged Off Amount": "Charged Off Amount",
-      "Date": "Date"
+      "Date": "Date",
+      "Auto-fill Holidays": "Auto-fill Holidays",
+      "Total": "Total",
+      "Active": "Active",
+      "Upcoming": "Upcoming",
+      "Holidays": "Holidays"
     },
     "inputs": {
       "accounting": {
@@ -2546,7 +2560,13 @@
       "Income from Buy down fees": "Income from Buy down fees",
       "Buy down fee Expense": "Buy down fee Expense",
       "Skip Interest Refund Transaction Posting": "Skip Interest Refund Transaction Posting",
-      "Available Disbursement Amount (with Over Applied)": "Available Disbursement Amount (with Over Applied)"
+      "Available Disbursement Amount (with Over Applied)": "Available Disbursement Amount (with Over Applied)",
+      "Year": "Year",
+      "Apply to offices": "Apply to offices",
+      "Repayments Scheduling Type": "Repayments scheduling type",
+      "Month": "Month",
+      "List": "List",
+      "All offices": "All offices"
     },
     "links": {
       "Community": "Community",
@@ -2728,7 +2748,8 @@
       "Are you sure you want to": "Are you sure you want to ",
       "the productmix component with id": "the productmix component with id",
       "the Reschedule Loan": " the Reschedule Loan",
-      "the Transaction Type": "the Transaction Type"
+      "the Transaction Type": "the Transaction Type",
+      "Are you sure you want to delete": "Are you sure you want to delete"
     },
     "text": {
       "A": "A",
@@ -3467,7 +3488,24 @@
       "Buy Down Fees": "Buy Down Fees",
       "Undo Write-off Description": "This action will reverse the write-off transaction and restore the loan to its previous active status. Please provide a note explaining the reason for this action.",
       "UploadDocumentHint": "Upload a PDF or image to generate a preview.",
-      "Create Savings Product": "Create Savings Product"
+      "Egypt official holidays via Google Calendar": "Egypt official holidays via Google Calendar",
+      "Loading holidays": "Loading holidays…",
+      "holidays imported": "holidays imported",
+      "failed to import": "failed to import",
+      "selected": "selected",
+      "Select an office to view holidays": "Pick an office to see its holidays.",
+      "No holidays defined": "No holidays defined yet.",
+      "Imported from Google Calendar": "Imported from Google Calendar",
+      "Importing": "Importing",
+      "No holidays match your filter": "No holidays match this filter.",
+      "No holidays this month": "No holidays this month.",
+      "Configure how payments due on non-working days behave": "Configure how payments due on non-working days behave.",
+      "Tap a day to toggle": "Tap a day to toggle whether it counts as a working day.",
+      "pending — select to activate": "pending — select to activate",
+      "Activating": "Activating",
+      "No changes to save": "No changes to save",
+      "Select to activate or delete": "Select to activate or delete",
+      "already-active rows will be skipped": "already-active rows will be skipped"
     },
     "auditTrail": {
       "actions": {


### PR DESCRIPTION
## Summary

- **Holidays page**: replaces the table with a Google-Calendar-style month view + a list view (tabs). Multi-day events render as colored bars that span across week rows, with a "+N more" overflow chip when a week has >3 lanes.
- **Bulk actions**: persistent per-row selection model — Activate (gated on `ACTIVATE_HOLIDAY`) and Delete (gated on `DELETE_HOLIDAY`) run with concurrency=3 and a determinate progress bar. Activate confirm dialog tells the user when non-pending rows in the selection will be skipped.
- **Auto-fill from Google**: imports Egyptian official holidays from `en.eg.official#holiday@group.v.calendar.google.com` via a public CORS proxy (corsproxy.io). Year picker, office chips, preview-with-checkboxes, then bulk-create. Uses ISO `yyyy-MM-dd` dates so the request is locale-immune.
- **Working days**: Saturday-first week order, day pills replace checkboxes, abbreviation-only labels with ARIA full names, "no changes to save" hint when pristine.
- **OnPush** change detection on all three new components; counts memoized; debounced (150ms) list filter; lazy list-view recompute.
- **Tests**: 25 new Jest cases for the iCal parser (RFC 5545 line folding, all-day inclusivity, escape sequences) and the lane allocator. Specs caught a real bug — tracking only \`lastEndCol\` per lane mis-stacked short spans at col 0 underneath earlier long spans at cols 4–6. Fixed to track all placed intervals per lane.
- **Refactor**: shared \`holiday-utils.ts\` exports \`Holiday\` model, date helpers, and a pure \`allocateLanes()\`. Replaces duplicated module-level helpers in two files.
- **i18n**: 38 new label keys in \`en-US.json\`. Other locales fall back to English in ngx-translate.

## Notable bug fix

The original create-holiday flow sent dates in the user's display locale (\`DD MMMM YYYY\`) but always claimed \`locale: 'en'\` to the backend — this fails with HTTP 400 when the user's display language is non-English (e.g. Arabic month names). The auto-import dialog uses ISO format to bypass this. The same fix should be applied to create-holiday and edit-holiday, but is **out of scope** for this PR.

## Test plan

- [x] Calendar view: navigate between months with prev/next/today; multi-day events span correctly; today is highlighted; out-of-month days are dimmed
- [x] List view: filter typing is debounced; status chips render Active / Pending / Deleted correctly
- [x] Bulk activate: select pending + active mix; confirm dialog mentions skipped count; progress bar advances
- [x] Bulk delete: confirm dialog has danger styling; rows disappear after success
- [x] Auto-fill: open dialog, fetch loads ~13 events for current year, select-all/clear, import progress, dialog closes on full success
- [x] Working days: Saturday-first; toggle day pills; "no changes to save" hint shows when pristine
- [x] Permissions: actions hide for users without \`ACTIVATE_HOLIDAY\` / \`DELETE_HOLIDAY\` / \`CREATE_HOLIDAY\`
- [x] Run \`npm test\` — 25 new specs pass
- [x] Run \`npm run lint\` — clean

## Out of scope

- Pre-existing dirty state in \`src/assets/env.js\`, \`src/environments/environment.ts\`, \`src/environments/.env.ts\` — left alone per request.
- CORS-proxy reliability concern for \`corsproxy.io\` — flagged but not addressed; replace with self-hosted proxy or Google Calendar API key auth in a follow-up.
- \`create-holiday\` / \`edit-holiday\` still use locale-dependent date formatting (same root cause as the auto-import bug above) — separate PR.