### PR TITLE
fix: dark-theme selectors and translation cache busting

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -86,7 +86,12 @@ export function HttpLoaderFactory(http: HttpClient) {
         provide: TranslateLoader,
         useFactory: (httpBackend: HttpBackend, locationStrategy: LocationStrategy) => {
           const http = new HttpClient(httpBackend);
-          return new TranslateHttpLoader(http, `/assets/translations/`, '.json');
+          // Append the build version as a cache-buster so a new bundle picks up
+          // the matching translations file instead of a stale browser-cached copy.
+          // The build runs with --output-hashing=none so without this query param
+          // browsers serve the previous deploy's en-US.json on every reload.
+          const suffix = `.json?v=${environment.version}-${environment.hash}`;
+          return new TranslateHttpLoader(http, `/assets/translations/`, suffix);
         },
         deps: [
           HttpBackend,

--- a/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.scss
+++ b/src/app/organization/holidays/holiday-auto-import-dialog/holiday-auto-import-dialog.component.scss
@@ -235,15 +235,13 @@
 }
 
 /* ---------- Dark mode ---------- */
-:host-context(.dark-mode),
-:host-context([data-theme='dark']) {
+:host-context(.dark-theme) {
   --ai-border: rgb(255 255 255 / 8%);
   --ai-text: rgb(255 255 255 / 92%);
   --ai-text-mid: rgb(255 255 255 / 65%);
   --ai-text-dim: rgb(255 255 255 / 45%);
 }
 
-:host-context(.dark-mode) .ai-item:hover,
-:host-context([data-theme='dark']) .ai-item:hover {
+:host-context(.dark-theme) .ai-item:hover {
   background: rgb(91 162 236 / 8%);
 }

--- a/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.scss
+++ b/src/app/organization/holidays/holiday-calendar/holiday-calendar.component.scss
@@ -230,8 +230,7 @@
 }
 
 /* ---------- Dark mode ---------- */
-:host-context(.dark-mode),
-:host-context([data-theme='dark']) {
+:host-context(.dark-theme) {
   --cal-border: rgb(255 255 255 / 8%);
   --cal-border-strong: rgb(255 255 255 / 16%);
   --cal-text-dim: rgb(255 255 255 / 38%);
@@ -240,14 +239,12 @@
   --cal-bg-out: rgb(255 255 255 / 2%);
 }
 
-:host-context(.dark-mode) .cal-bar,
-:host-context([data-theme='dark']) .cal-bar {
+:host-context(.dark-theme) .cal-bar {
   background: oklch(28% 0.06 var(--hue, 220));
   color: oklch(82% 0.1 var(--hue, 220));
 }
 
-:host-context(.dark-mode) .cal-day:hover,
-:host-context([data-theme='dark']) .cal-day:hover {
+:host-context(.dark-theme) .cal-day:hover {
   background: rgb(91 162 236 / 8%);
 }
 

--- a/src/app/organization/holidays/holidays.component.scss
+++ b/src/app/organization/holidays/holidays.component.scss
@@ -413,8 +413,7 @@
 }
 
 /* ---------- Dark mode ---------- */
-:host-context(.dark-mode),
-:host-context([data-theme='dark']) {
+:host-context(.dark-theme) {
   --hl-border: rgb(255 255 255 / 8%);
   --hl-border-strong: rgb(255 255 255 / 16%);
   --hl-text: rgb(255 255 255 / 92%);
@@ -422,13 +421,11 @@
   --hl-text-dim: rgb(255 255 255 / 45%);
 }
 
-:host-context(.dark-mode) .hl-list-group-head,
-:host-context([data-theme='dark']) .hl-list-group-head {
+:host-context(.dark-theme) .hl-list-group-head {
   background: rgb(20 28 40 / 92%);
 }
 
-:host-context(.dark-mode) .hl-row:hover,
-:host-context([data-theme='dark']) .hl-row:hover {
+:host-context(.dark-theme) .hl-row:hover {
   background: rgb(91 162 236 / 8%);
 }
 

--- a/src/app/organization/working-days/working-days.component.scss
+++ b/src/app/organization/working-days/working-days.component.scss
@@ -179,34 +179,28 @@
 }
 
 /* ---------- Dark mode ---------- */
-:host-context(.dark-mode) .wd-page-title,
-:host-context([data-theme='dark']) .wd-page-title {
+:host-context(.dark-theme) .wd-page-title {
   color: rgb(255 255 255 / 92%);
 }
 
-:host-context(.dark-mode) .wd-pill,
-:host-context([data-theme='dark']) .wd-pill {
+:host-context(.dark-theme) .wd-pill {
   border-color: rgb(255 255 255 / 14%);
   background: rgb(255 255 255 / 3%);
   color: rgb(255 255 255 / 65%);
 }
 
-:host-context(.dark-mode) .wd-pill:hover,
-:host-context([data-theme='dark']) .wd-pill:hover {
+:host-context(.dark-theme) .wd-pill:hover {
   border-color: rgb(91 162 236 / 60%);
   background: rgb(91 162 236 / 8%);
   color: rgb(255 255 255 / 92%);
 }
 
-:host-context(.dark-mode) .wd-section-title,
-:host-context([data-theme='dark']) .wd-section-title {
+:host-context(.dark-theme) .wd-section-title {
   color: rgb(255 255 255 / 72%);
 }
 
-:host-context(.dark-mode) .wd-page-head,
-:host-context([data-theme='dark']) .wd-page-head,
-:host-context(.dark-mode) .wd-actions,
-:host-context([data-theme='dark']) .wd-actions {
+:host-context(.dark-theme) .wd-page-head,
+:host-context(.dark-theme) .wd-actions {
   border-color: rgb(255 255 255 / 8%);
 }
 


### PR DESCRIPTION
Follow-up to #5. Two staging bugs surfaced once the redesign was deployed.

## Bugs

1. **Dark mode never applied** to the new components.
   - The new SCSS targeted \`:host-context(.dark-mode)\` and \`:host-context([data-theme='dark'])\`.
   - Mifos's \`ThemingService\` toggles \`body.dark-theme\` (see \`src/app/shared/theme-toggle/theming.service.ts:43\`).
   - Neither selector matched, so the components fell back to default light styles inside a dark-themed body — which is what "broken in dark mode" looked like.

2. **New translation keys rendered as raw strings** (\`labels.heading.Holidays\`, \`labels.buttons.Auto-fill from Google\`, etc.).
   - Production build runs with \`--output-hashing=none\`.
   - \`/assets/translations/en-US.json\` is loaded at runtime by \`TranslateHttpLoader\` from a fixed URL.
   - Browsers had cached the previous deploy's en-US.json (without the new keys) and kept serving it after the new deploy.
   - The bundle had the new keys; the JSON the browser actually fetched did not.

## Fix

- Renamed every \`:host-context(.dark-mode)\` to \`:host-context(.dark-theme)\` across the four new SCSS files; removed the dead \`[data-theme='dark']\` selector duplicates.
- Append \`?v=\${environment.version}-\${environment.hash}\` to the \`TranslateHttpLoader\` suffix in \`app.module.ts\`. Each build now fetches a unique URL, bypassing the HTTP cache without disabling caching wholesale.

## Test plan

- [ ] Toggle system dark mode (or set \`body.classList.add('dark-theme')\` in devtools): calendar, holidays list, working-days, and auto-import dialog all apply dark surfaces and adjusted text/border tints
- [ ] Deploy and reload without manual cache clear: page heading reads "Holidays", tabs read "Month" / "List", action buttons read "Auto-fill from Google" / "Today", etc.
- [ ] Network tab: \`/assets/translations/en-US.json?v=<version>-<hash>\` is requested; the cached entry without the query string is no longer used