### PR TITLE
fix: dark-mode contrast on working-days pills and Create Holiday button

### DIFF
--- a/src/app/organization/holidays/holidays.component.scss
+++ b/src/app/organization/holidays/holidays.component.scss
@@ -109,6 +109,16 @@
   font-size: 13px !important;
   font-weight: 500 !important;
   letter-spacing: 0.01em;
+
+  /* Pin the button to the brand blue across themes — Material's dark palette
+     resolves `color="primary"` to a lighter washed-out shade that doesn't
+     match the brand. */
+  background-color: #1074b9 !important;
+  color: #fff !important;
+}
+
+.hl-create-btn:hover {
+  background-color: #0d6aaa !important;
 }
 
 /* ---------- Tabs ---------- */
@@ -414,15 +424,25 @@
 
 /* ---------- Dark mode ---------- */
 :host-context(.dark-theme) {
-  --hl-border: rgb(255 255 255 / 8%);
-  --hl-border-strong: rgb(255 255 255 / 16%);
-  --hl-text: rgb(255 255 255 / 92%);
-  --hl-text-mid: rgb(255 255 255 / 65%);
-  --hl-text-dim: rgb(255 255 255 / 45%);
+  --hl-border: rgb(255 255 255 / 16%);
+  --hl-border-strong: rgb(255 255 255 / 28%);
+  --hl-text: rgb(255 255 255 / 95%);
+  --hl-text-mid: rgb(255 255 255 / 75%);
+  --hl-text-dim: rgb(255 255 255 / 55%);
+  --hl-accent: #5ba2ec;
 }
 
 :host-context(.dark-theme) .hl-list-group-head {
   background: rgb(20 28 40 / 92%);
+}
+
+:host-context(.dark-theme) .hl-bulkbar {
+  background: rgb(255 255 255 / 4%);
+}
+
+:host-context(.dark-theme) .hl-bulkbar.is-active {
+  background: rgb(91 162 236 / 12%);
+  border-color: rgb(91 162 236 / 50%);
 }
 
 :host-context(.dark-theme) .hl-row:hover {

--- a/src/app/organization/working-days/working-days.component.scss
+++ b/src/app/organization/working-days/working-days.component.scss
@@ -180,28 +180,59 @@
 
 /* ---------- Dark mode ---------- */
 :host-context(.dark-theme) .wd-page-title {
-  color: rgb(255 255 255 / 92%);
+  color: rgb(255 255 255 / 95%);
 }
 
-:host-context(.dark-theme) .wd-pill {
-  border-color: rgb(255 255 255 / 14%);
-  background: rgb(255 255 255 / 3%);
+:host-context(.dark-theme) .wd-page-meta {
   color: rgb(255 255 255 / 65%);
 }
 
+:host-context(.dark-theme) .wd-page-meta > span:first-child {
+  color: #5ba2ec;
+}
+
+:host-context(.dark-theme) .wd-pill {
+  border-color: rgb(255 255 255 / 28%);
+  background: rgb(255 255 255 / 6%);
+  color: rgb(255 255 255 / 88%);
+}
+
 :host-context(.dark-theme) .wd-pill:hover {
-  border-color: rgb(91 162 236 / 60%);
-  background: rgb(91 162 236 / 8%);
-  color: rgb(255 255 255 / 92%);
+  border-color: #5ba2ec;
+  background: rgb(91 162 236 / 14%);
+  color: rgb(255 255 255 / 100%);
+}
+
+:host-context(.dark-theme) .wd-pill.is-active {
+  background: #1074b9;
+  border-color: #5ba2ec;
+  color: #fff;
+}
+
+:host-context(.dark-theme) .wd-pill.is-active:hover {
+  background: #1383d0;
+  border-color: #7ab4ef;
 }
 
 :host-context(.dark-theme) .wd-section-title {
-  color: rgb(255 255 255 / 72%);
+  color: rgb(255 255 255 / 85%);
+}
+
+:host-context(.dark-theme) .wd-section-hint {
+  color: rgb(255 255 255 / 60%);
+}
+
+:host-context(.dark-theme) .wd-toggle {
+  color: rgb(255 255 255 / 88%);
+}
+
+:host-context(.dark-theme) .wd-actions-hint {
+  color: rgb(255 255 255 / 55%);
 }
 
 :host-context(.dark-theme) .wd-page-head,
 :host-context(.dark-theme) .wd-actions {
-  border-color: rgb(255 255 255 / 8%);
+  border-color: rgb(255 255 255 / 14%);
 }
 
 /* ---------- Responsive ---------- */


### PR DESCRIPTION
Two staging dark-mode regressions surfaced after the previous fixes merged.

## Bugs

1. **Working-days day pills are nearly invisible in dark mode.**
   - Off-state used 14% white border + 3% white background + 65% white text. On the staging dark surface those alphas wash out — the pills read as faint outlines with text you can barely see.
   - Section hints, the toggle row, and the "no changes to save" hint were also inheriting low-alpha light-mode colors.

2. **"Create Holiday" button color is wrong in dark mode.**
   - The button uses Material's \`color="primary"\`, which the dark palette resolves to a lighter washed shade that doesn't match the Mifos brand blue.

## Fix

- **Working days** (\`working-days.component.scss\`):
  - Pill off-state bumped to 28% border / 6% bg / 88% text — readable surface.
  - Explicit dark-theme rules added for hover, active, and active-hover so the brand fill behaves consistently.
  - Added dark-theme overrides for \`.wd-page-meta\`, \`.wd-section-hint\`, \`.wd-toggle\`, and \`.wd-actions-hint\`.

- **Holidays** (\`holidays.component.scss\`):
  - Pinned \`.hl-create-btn\` to \`#1074b9\` with explicit \`!important\` so it reads the same brand blue across themes; added a hover state.
  - Bumped the dark-mode \`--hl-border\`, \`--hl-text-mid\`, \`--hl-text-dim\` alphas to legible values; switched \`--hl-accent\` to \`#5ba2ec\` (Mifos's lighter brand variant) for non-button accents in dark mode.
  - Bulk-action bar gets a brighter dark-mode background and a stronger active-state outline.

## Test plan

- [ ] Toggle dark mode: working-days pills show clear borders, readable text, and a visible hover state
- [ ] Working-days dark: section labels, hints, toggle row, and the "no changes to save" hint all readable
- [ ] Holidays dark: "Create Holiday" button is the same brand blue as in light mode (not washed)
- [ ] Holidays dark: bulk action bar has visible borders; "is-selected" state shows clear active outline
- [ ] Light mode: nothing visually regresses